### PR TITLE
広告テンプレート管理機能の修正と改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # 広告管理システム (Ado) MVP
 
+![Next.js](https://img.shields.io/badge/Next.js-15.4.5-black?style=flat-square&logo=next.js)
+![React](https://img.shields.io/badge/React-19.1.0-blue?style=flat-square&logo=react)
+![TypeScript](https://img.shields.io/badge/TypeScript-5-blue?style=flat-square&logo=typescript)
+![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-v4-38B2AC?style=flat-square&logo=tailwind-css)
+![NextAuth.js](https://img.shields.io/badge/NextAuth.js-5.0.0--beta-purple?style=flat-square)
+![Jest](https://img.shields.io/badge/Jest-29.7.0-C21325?style=flat-square&logo=jest)
+
 LMG向けの内部メディア（PORTキャリアなど）の広告管理システムMVPです。
 
 ## プロジェクト概要
 
-このプロジェクトはNext.js、TypeScript、Tailwind CSS、NextAuth.jsを使用して構築された日本語の広告管理システムです。認証機能とアカウント管理機能を備えた本格的なWebアプリケーションとして開発されています。
+このプロジェクトはNext.js、TypeScript、Tailwind
+CSS、NextAuth.jsを使用して構築された日本語の広告管理システムです。認証機能とアカウント管理機能を備えた本格的なWebアプリケーションとして開発されています。
 
 ### 主な機能
 
@@ -16,46 +24,57 @@ LMG向けの内部メディア（PORTキャリアなど）の広告管理シス�
 - **🔗 記事と広告の紐付け管理** - コンテンツと広告の関連付け
 - **👥 アカウント管理** - ユーザーアカウント管理システム
 
-## セットアップ手順
+## 🚀 クイックスタート
 
-### 1. 依存関係のインストール
+### 前提条件
 
-```bash
-npm install
-```
+- Node.js 18.17以上
+- npm または yarn
+- Neon PostgreSQL データベース
 
-### 2. 環境変数の設定
+### セットアップ手順
 
-`.env.local`ファイルを作成し、以下の環境変数を設定してください：
+1. **リポジトリのクローン**
+   ```bash
+   git clone <repository-url>
+   cd pj-ado-mvp
+   ```
 
-```env
-DATABASE_URL=your_neon_database_url
-NEXTAUTH_SECRET=your_nextauth_secret
-NEXTAUTH_URL=http://localhost:3000
-```
+2. **依存関係のインストール**
+   ```bash
+   npm install
+   ```
 
-### 3. データベースの初期化
+3. **環境変数の設定**
 
-```bash
-node scripts/seed.js
-```
+   `.env.local`ファイルを作成し、以下の環境変数を設定：
+   ```env
+   DATABASE_URL=your_neon_database_url
+   NEXTAUTH_SECRET=your_nextauth_secret_key_32_characters_long
+   NEXTAUTH_URL=http://localhost:3000
+   ```
 
-このコマンドにより、usersテーブルとad_templatesテーブルが作成され、テストユーザーとサンプルテンプレートがシードされます。
+4. **データベースの初期化**
+   ```bash
+   node scripts/seed.js
+   ```
+   > このコマンドにより、usersテーブルとad_templatesテーブルが作成され、テストユーザーとサンプルテンプレートがシードされます。
 
-### 4. 開発サーバーの起動
+5. **開発サーバーの起動**
+   ```bash
+   npm run dev
+   ```
 
-```bash
-npm run dev
-```
+   ブラウザで [http://localhost:3000](http://localhost:3000) を開いてください。
 
-ブラウザで [http://localhost:3000](http://localhost:3000) を開いてください。
-
-## ログイン情報
+## 🔐 ログイン情報
 
 開発・テスト用のログイン情報：
 
-- **管理者アカウント**: `admin@example.com` / `password123`
-- **編集者アカウント**: `editor@example.com` / `password123`
+| 役割      | メールアドレス              | パスワード         | 権限          |
+|---------|----------------------|---------------|-------------|
+| **管理者** | `admin@example.com`  | `password123` | 全機能アクセス     |
+| **編集者** | `editor@example.com` | `password123` | テンプレート・広告管理 |
 
 ## 技術スタック
 
@@ -173,20 +192,20 @@ pj-ado-mvp/
 
 ### 広告テンプレート API
 
-| エンドポイント | メソッド | 説明 | 認証 |
-|-------------|--------|------|------|
-| `/api/templates` | GET | 全テンプレート取得 | 必須 |
-| `/api/templates` | POST | 新規テンプレート作成 | 必須 |
-| `/api/templates/[id]` | GET | 個別テンプレート取得 | 必須 |
-| `/api/templates/[id]` | PUT | テンプレート更新 | 必須 |
-| `/api/templates/[id]` | DELETE | テンプレート削除 | 必須 |
-| `/api/templates/import` | POST | CSVからテンプレートインポート | 必須 |
-| `/api/templates/export` | GET | テンプレートをCSVエクスポート | 必須 |
+| エンドポイント                 | メソッド   | 説明               | 認証 |
+|-------------------------|--------|------------------|----|
+| `/api/templates`        | GET    | 全テンプレート取得        | 必須 |
+| `/api/templates`        | POST   | 新規テンプレート作成       | 必須 |
+| `/api/templates/[id]`   | GET    | 個別テンプレート取得       | 必須 |
+| `/api/templates/[id]`   | PUT    | テンプレート更新         | 必須 |
+| `/api/templates/[id]`   | DELETE | テンプレート削除         | 必須 |
+| `/api/templates/import` | POST   | CSVからテンプレートインポート | 必須 |
+| `/api/templates/export` | GET    | テンプレートをCSVエクスポート | 必須 |
 
 ### 認証 API
 
-| エンドポイント | メソッド | 説明 |
-|-------------|--------|------|
+| エンドポイント                   | メソッド     | 説明                  |
+|---------------------------|----------|---------------------|
 | `/api/auth/[...nextauth]` | GET/POST | NextAuth.js 認証ハンドラー |
 
 ## 認証・認可について
@@ -206,15 +225,15 @@ pj-ado-mvp/
 
 システムでは2段階の役割システムを実装：
 
-| 役割 | レベル | 権限 |
-|------|--------|------|
-| **管理者 (admin)** | 2 | 全機能アクセス、ユーザー管理、テンプレート管理 |
-| **編集者 (editor)** | 1 | テンプレート作成・編集、広告管理 |
+| 役割               | レベル | 権限                      |
+|------------------|-----|-------------------------|
+| **管理者 (admin)**  | 2   | 全機能アクセス、ユーザー管理、テンプレート管理 |
+| **編集者 (editor)** | 1   | テンプレート作成・編集、広告管理        |
 
 #### 認可ヘルパー関数
 
 - `hasMinimumRole(user, role)` - 最小権限チェック
-- `isAdmin(user)` - 管理者権限チェック  
+- `isAdmin(user)` - 管理者権限チェック
 - `canEdit(user)` - 編集権限チェック
 - `withAuthorization(handler, requiredRole)` - API認可ラッパー
 
@@ -228,27 +247,27 @@ pj-ado-mvp/
 
 ### users テーブル
 
-| カラム | 型 | 説明 | 制約 |
-|--------|-----|------|------|
-| `id` | SERIAL | プライマリキー | PRIMARY KEY |
-| `name` | VARCHAR(255) | ユーザー名 | NOT NULL |
-| `email` | VARCHAR(255) | メールアドレス | UNIQUE, NOT NULL |
-| `password` | VARCHAR(255) | bcryptハッシュ化パスワード | NOT NULL |
-| `role` | VARCHAR(20) | ユーザー役割 (admin/editor) | NOT NULL, DEFAULT 'editor' |
-| `created_at` | TIMESTAMP | 作成日時 | DEFAULT NOW() |
-| `updated_at` | TIMESTAMP | 更新日時 | DEFAULT NOW() |
+| カラム          | 型            | 説明                    | 制約                         |
+|--------------|--------------|-----------------------|----------------------------|
+| `id`         | SERIAL       | プライマリキー               | PRIMARY KEY                |
+| `name`       | VARCHAR(255) | ユーザー名                 | NOT NULL                   |
+| `email`      | VARCHAR(255) | メールアドレス               | UNIQUE, NOT NULL           |
+| `password`   | VARCHAR(255) | bcryptハッシュ化パスワード      | NOT NULL                   |
+| `role`       | VARCHAR(20)  | ユーザー役割 (admin/editor) | NOT NULL, DEFAULT 'editor' |
+| `created_at` | TIMESTAMP    | 作成日時                  | DEFAULT NOW()              |
+| `updated_at` | TIMESTAMP    | 更新日時                  | DEFAULT NOW()              |
 
 ### ad_templates テーブル
 
-| カラム | 型 | 説明 | 制約 |
-|--------|-----|------|------|
-| `id` | SERIAL | プライマリキー | PRIMARY KEY |
-| `name` | VARCHAR(255) | テンプレート名 | NOT NULL |
-| `html` | TEXT | HTMLテンプレート | NOT NULL |
-| `placeholders` | JSON | プレースホルダー配列 | |
-| `description` | TEXT | テンプレート説明 | |
-| `created_at` | TIMESTAMP | 作成日時 | DEFAULT NOW() |
-| `updated_at` | TIMESTAMP | 更新日時 | DEFAULT NOW() |
+| カラム            | 型            | 説明         | 制約            |
+|----------------|--------------|------------|---------------|
+| `id`           | SERIAL       | プライマリキー    | PRIMARY KEY   |
+| `name`         | VARCHAR(255) | テンプレート名    | NOT NULL      |
+| `html`         | TEXT         | HTMLテンプレート | NOT NULL      |
+| `placeholders` | JSON         | プレースホルダー配列 |               |
+| `description`  | TEXT         | テンプレート説明   |               |
+| `created_at`   | TIMESTAMP    | 作成日時       | DEFAULT NOW() |
+| `updated_at`   | TIMESTAMP    | 更新日時       | DEFAULT NOW() |
 
 ## テンプレートシステム
 

--- a/__tests__/components/Button.test.tsx
+++ b/__tests__/components/Button.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Button } from '@/components/Button';
+
+describe('Button', () => {
+  it('renders button with children', () => {
+    render(<Button>Click me</Button>);
+    
+    const button = screen.getByRole('button', { name: 'Click me' });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = { current: null };
+    render(<Button ref={ref}>Test</Button>);
+    
+    expect(ref.current).not.toBeNull();
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+  });
+
+  it('applies custom className along with default styles', () => {
+    render(<Button className="custom-class">Test</Button>);
+    
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('custom-class');
+    expect(button).toHaveClass('bg-blue-600');
+  });
+
+  it('handles click events', () => {
+    const handleClick = jest.fn();
+    render(<Button onClick={handleClick}>Click me</Button>);
+    
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through button props', () => {
+    render(
+      <Button type="submit" disabled aria-label="Submit form">
+        Submit
+      </Button>
+    );
+    
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('type', 'submit');
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-label', 'Submit form');
+  });
+
+  it('applies disabled styling when aria-disabled is true', () => {
+    render(<Button aria-disabled="true">Disabled</Button>);
+    
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('aria-disabled:cursor-not-allowed');
+    expect(button).toHaveClass('aria-disabled:opacity-50');
+  });
+});

--- a/__tests__/components/ClientLayout.test.tsx
+++ b/__tests__/components/ClientLayout.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen } from '@testing-library/react';
+import { useSession } from 'next-auth/react';
+import ClientLayout from '@/components/ClientLayout';
+
+// Mock next-auth/react
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+}));
+
+// Mock Sidebar component
+jest.mock('@/components/Sidebar', () => {
+  return jest.fn(() => <div data-testid="sidebar">Sidebar Component</div>);
+});
+
+const mockUseSession = useSession as jest.MockedFunction<typeof useSession>;
+
+describe('ClientLayout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows loading spinner when session is loading', () => {
+    mockUseSession.mockReturnValue({
+      data: null,
+      status: 'loading',
+    });
+
+    render(
+      <ClientLayout>
+        <div>Test Content</div>
+      </ClientLayout>
+    );
+
+    expect(screen.getByTestId('loading-spinner')).toHaveClass('animate-spin');
+    expect(screen.queryByText('Test Content')).not.toBeInTheDocument();
+  });
+
+  it('renders authenticated layout when user is logged in', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: { id: '1', email: 'test@example.com', role: 'admin' },
+      },
+      status: 'authenticated',
+    });
+
+    render(
+      <ClientLayout>
+        <div>Test Content</div>
+      </ClientLayout>
+    );
+
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument();
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+    
+    // Check that main content has the authenticated layout classes
+    const mainContent = screen.getByText('Test Content').closest('main');
+    expect(mainContent).toHaveClass('ml-64');
+  });
+
+  it('renders unauthenticated layout when user is not logged in', () => {
+    mockUseSession.mockReturnValue({
+      data: null,
+      status: 'unauthenticated',
+    });
+
+    render(
+      <ClientLayout>
+        <div>Test Content</div>
+      </ClientLayout>
+    );
+
+    expect(screen.queryByTestId('sidebar')).not.toBeInTheDocument();
+    expect(screen.getByText('LMG 広告管理')).toBeInTheDocument();
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+    
+    // Check that main content does not have the ml-64 class
+    const mainContent = screen.getByText('Test Content').closest('main');
+    expect(mainContent).not.toHaveClass('ml-64');
+  });
+
+  it('renders unauthenticated layout when session data is null', () => {
+    mockUseSession.mockReturnValue({
+      data: { user: null },
+      status: 'unauthenticated',
+    });
+
+    render(
+      <ClientLayout>
+        <div>Test Content</div>
+      </ClientLayout>
+    );
+
+    expect(screen.queryByTestId('sidebar')).not.toBeInTheDocument();
+    expect(screen.getByText('LMG 広告管理')).toBeInTheDocument();
+  });
+
+  it('renders multiple children correctly in authenticated layout', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: { id: '1', email: 'test@example.com', role: 'admin' },
+      },
+      status: 'authenticated',
+    });
+
+    render(
+      <ClientLayout>
+        <div>First Child</div>
+        <div>Second Child</div>
+      </ClientLayout>
+    );
+
+    expect(screen.getByText('First Child')).toBeInTheDocument();
+    expect(screen.getByText('Second Child')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument();
+  });
+
+  it('renders multiple children correctly in unauthenticated layout', () => {
+    mockUseSession.mockReturnValue({
+      data: null,
+      status: 'unauthenticated',
+    });
+
+    render(
+      <ClientLayout>
+        <div>First Child</div>
+        <div>Second Child</div>
+      </ClientLayout>
+    );
+
+    expect(screen.getByText('First Child')).toBeInTheDocument();
+    expect(screen.getByText('Second Child')).toBeInTheDocument();
+    expect(screen.getByText('LMG 広告管理')).toBeInTheDocument();
+  });
+
+  it('has proper styling for authenticated main content', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: { id: '1', email: 'test@example.com', role: 'admin' },
+      },
+      status: 'authenticated',
+    });
+
+    render(
+      <ClientLayout>
+        <div>Test Content</div>
+      </ClientLayout>
+    );
+
+    const mainContent = screen.getByText('Test Content').closest('main');
+    expect(mainContent).toHaveClass('flex-1', 'ml-64', 'p-8', 'bg-gray-50', 'min-h-screen');
+  });
+
+  it('has proper styling for unauthenticated main content', () => {
+    mockUseSession.mockReturnValue({
+      data: null,
+      status: 'unauthenticated',
+    });
+
+    render(
+      <ClientLayout>
+        <div>Test Content</div>
+      </ClientLayout>
+    );
+
+    const mainContent = screen.getByText('Test Content').closest('main');
+    expect(mainContent).toHaveClass('p-8', 'bg-gray-50', 'min-h-screen');
+    expect(mainContent).not.toHaveClass('ml-64');
+  });
+});

--- a/__tests__/components/ImportExportButtons.test.tsx
+++ b/__tests__/components/ImportExportButtons.test.tsx
@@ -1,0 +1,216 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ImportExportButtons from '@/app/ad-templates/components/ImportExportButtons';
+
+interface ImportResult {
+  success: number;
+  errors: string[];
+  total: number;
+}
+
+describe('ImportExportButtons', () => {
+  const mockOnImport = jest.fn();
+  const mockOnExport = jest.fn();
+  const mockOnCreateClick = jest.fn();
+  const mockOnImportCancel = jest.fn();
+  const mockHandleImport = jest.fn();
+
+  const defaultProps = {
+    onImport: mockOnImport,
+    onExport: mockOnExport,
+    onCreateClick: mockOnCreateClick,
+    onImportCancel: mockOnImportCancel,
+    exportLoading: false,
+    showImportForm: false,
+    importLoading: false,
+    importResult: null,
+    handleImport: mockHandleImport,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders all buttons correctly', () => {
+    render(<ImportExportButtons {...defaultProps} />);
+    
+    expect(screen.getByText('広告テンプレート管理')).toBeInTheDocument();
+    expect(screen.getByText('CSVインポート')).toBeInTheDocument();
+    expect(screen.getByText('CSVエクスポート')).toBeInTheDocument();
+    expect(screen.getByText('新しいテンプレートを作成')).toBeInTheDocument();
+  });
+
+  it('calls onImport when import button is clicked', () => {
+    render(<ImportExportButtons {...defaultProps} />);
+    
+    fireEvent.click(screen.getByText('CSVインポート'));
+    
+    expect(mockOnImport).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onExport when export button is clicked', () => {
+    render(<ImportExportButtons {...defaultProps} />);
+    
+    fireEvent.click(screen.getByText('CSVエクスポート'));
+    
+    expect(mockOnExport).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCreateClick when create button is clicked', () => {
+    render(<ImportExportButtons {...defaultProps} />);
+    
+    fireEvent.click(screen.getByText('新しいテンプレートを作成'));
+    
+    expect(mockOnCreateClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows loading state for export button', () => {
+    const propsWithExportLoading = {
+      ...defaultProps,
+      exportLoading: true,
+    };
+    
+    render(<ImportExportButtons {...propsWithExportLoading} />);
+    
+    expect(screen.getByText('エクスポート中...')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'エクスポート中...' })).toBeDisabled();
+  });
+
+  it('shows import form when showImportForm is true', () => {
+    const propsWithImportForm = {
+      ...defaultProps,
+      showImportForm: true,
+    };
+    
+    render(<ImportExportButtons {...propsWithImportForm} />);
+    
+    expect(screen.getByText('CSVファイルからインポート')).toBeInTheDocument();
+    expect(screen.getByText('CSVファイルを選択')).toBeInTheDocument();
+    expect(screen.getByText('キャンセル')).toBeInTheDocument();
+  });
+
+  it('calls onImportCancel when cancel button is clicked', () => {
+    const propsWithImportForm = {
+      ...defaultProps,
+      showImportForm: true,
+    };
+    
+    render(<ImportExportButtons {...propsWithImportForm} />);
+    
+    fireEvent.click(screen.getByText('キャンセル'));
+    
+    expect(mockOnImportCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows import loading state', () => {
+    const propsWithImportLoading = {
+      ...defaultProps,
+      showImportForm: true,
+      importLoading: true,
+    };
+    
+    render(<ImportExportButtons {...propsWithImportLoading} />);
+    
+    expect(screen.getByText('インポート中...')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'インポート中...' })).toBeDisabled();
+  });
+
+  it('displays successful import result', () => {
+    const successResult: ImportResult = {
+      success: 5,
+      errors: [],
+      total: 5,
+    };
+    
+    const propsWithSuccessResult = {
+      ...defaultProps,
+      showImportForm: true,
+      importResult: successResult,
+    };
+    
+    render(<ImportExportButtons {...propsWithSuccessResult} />);
+    
+    expect(screen.getByText('インポート結果')).toBeInTheDocument();
+    expect(screen.getByText('処理総数:')).toBeInTheDocument();
+    expect(screen.getByText('成功:')).toBeInTheDocument();
+  });
+
+  it('displays import result with errors', () => {
+    const resultWithErrors: ImportResult = {
+      success: 3,
+      errors: ['Error 1', 'Error 2'],
+      total: 5,
+    };
+    
+    const propsWithErrorResult = {
+      ...defaultProps,
+      showImportForm: true,
+      importResult: resultWithErrors,
+    };
+    
+    render(<ImportExportButtons {...propsWithErrorResult} />);
+    
+    expect(screen.getByText('インポート結果')).toBeInTheDocument();
+    expect(screen.getByText('処理総数:')).toBeInTheDocument();
+    expect(screen.getByText('成功:')).toBeInTheDocument();
+    expect(screen.getByText('エラー:')).toBeInTheDocument();
+    expect(screen.getByText('Error 1')).toBeInTheDocument();
+    expect(screen.getByText('Error 2')).toBeInTheDocument();
+  });
+
+  it('calls handleImport when import form is submitted', () => {
+    const propsWithImportForm = {
+      ...defaultProps,
+      showImportForm: true,
+    };
+    
+    render(<ImportExportButtons {...propsWithImportForm} />);
+    
+    const form = screen.getByRole('button', { name: 'インポート実行' }).closest('form');
+    fireEvent.submit(form!);
+    
+    expect(mockHandleImport).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows CSV format guide in import form', () => {
+    const propsWithImportForm = {
+      ...defaultProps,
+      showImportForm: true,
+    };
+    
+    render(<ImportExportButtons {...propsWithImportForm} />);
+    
+    expect(screen.getByText('以下の形式でCSVファイルを作成してください（1行目はヘッダー行です）')).toBeInTheDocument();
+    expect(screen.getByText('name,html,placeholders,description')).toBeInTheDocument();
+  });
+
+  it('has proper file input attributes', () => {
+    const propsWithImportForm = {
+      ...defaultProps,
+      showImportForm: true,
+    };
+    
+    render(<ImportExportButtons {...propsWithImportForm} />);
+    
+    const fileInput = screen.getByLabelText('CSVファイルを選択');
+    expect(fileInput).toHaveAttribute('type', 'file');
+    expect(fileInput).toHaveAttribute('accept', '.csv');
+    expect(fileInput).toHaveAttribute('name', 'file');
+    expect(fileInput).toBeRequired();
+  });
+
+  it('disables import form when loading', () => {
+    const propsWithImportLoading = {
+      ...defaultProps,
+      showImportForm: true,
+      importLoading: true,
+    };
+    
+    render(<ImportExportButtons {...propsWithImportLoading} />);
+    
+    const fileInput = screen.getByLabelText('CSVファイルを選択');
+    expect(fileInput).toBeDisabled();
+    
+    const cancelButton = screen.getByText('キャンセル');
+    expect(cancelButton).toBeDisabled();
+  });
+});

--- a/__tests__/components/LoginForm.test.tsx
+++ b/__tests__/components/LoginForm.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { signIn } from 'next-auth/react';
+import LoginForm from '@/components/LoginForm';
+
+// Mock next-auth/react
+jest.mock('next-auth/react', () => ({
+  signIn: jest.fn(),
+}));
+
+const mockSignIn = signIn as jest.MockedFunction<typeof signIn>;
+
+describe('LoginForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders login form with all required fields', () => {
+    render(<LoginForm />);
+    
+    expect(screen.getByRole('heading', { name: 'ログイン' })).toBeInTheDocument();
+    expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument();
+    expect(screen.getByLabelText('パスワード')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'ログイン' })).toBeInTheDocument();
+  });
+
+  it('has proper form field attributes', () => {
+    render(<LoginForm />);
+    
+    const emailInput = screen.getByLabelText('メールアドレス');
+    const passwordInput = screen.getByLabelText('パスワード');
+    
+    expect(emailInput).toHaveAttribute('type', 'email');
+    expect(emailInput).toHaveAttribute('name', 'email');
+    expect(emailInput).toBeRequired();
+    
+    expect(passwordInput).toHaveAttribute('type', 'password');
+    expect(passwordInput).toHaveAttribute('name', 'password');
+    expect(passwordInput).toBeRequired();
+    expect(passwordInput).toHaveAttribute('minLength', '8');
+  });
+
+  it('calls signIn when form is submitted', async () => {
+    mockSignIn.mockResolvedValue(undefined);
+    
+    render(<LoginForm />);
+    
+    const emailInput = screen.getByLabelText('メールアドレス');
+    const passwordInput = screen.getByLabelText('パスワード');
+    const submitButton = screen.getByRole('button', { name: 'ログイン' });
+    
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+    fireEvent.click(submitButton);
+    
+    await waitFor(() => {
+      expect(mockSignIn).toHaveBeenCalledWith('credentials', expect.objectContaining({
+        redirectTo: '/dashboard',
+      }));
+    });
+  });
+
+  it('shows loading state during authentication', async () => {
+    mockSignIn.mockImplementation(() => new Promise(resolve => setTimeout(resolve, 100)));
+    
+    render(<LoginForm />);
+    
+    const emailInput = screen.getByLabelText('メールアドレス');
+    const passwordInput = screen.getByLabelText('パスワード');
+    const submitButton = screen.getByRole('button', { name: 'ログイン' });
+    
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+    fireEvent.click(submitButton);
+    
+    expect(screen.getByText('ログイン中...')).toBeInTheDocument();
+    expect(submitButton).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('displays error message when authentication fails', async () => {
+    mockSignIn.mockRejectedValue(new Error('Authentication failed'));
+    
+    render(<LoginForm />);
+    
+    const emailInput = screen.getByLabelText('メールアドレス');
+    const passwordInput = screen.getByLabelText('パスワード');
+    const submitButton = screen.getByRole('button', { name: 'ログイン' });
+    
+    fireEvent.change(emailInput, { target: { value: 'invalid@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'wrongpassword' } });
+    fireEvent.click(submitButton);
+    
+    await waitFor(() => {
+      expect(screen.getByText('メールアドレスまたはパスワードが正しくありません。')).toBeInTheDocument();
+    });
+  });
+
+  it('clears error message on new submission attempt', async () => {
+    mockSignIn.mockRejectedValueOnce(new Error('Authentication failed'))
+            .mockResolvedValueOnce(undefined);
+    
+    render(<LoginForm />);
+    
+    const emailInput = screen.getByLabelText('メールアドレス');
+    const passwordInput = screen.getByLabelText('パスワード');
+    const submitButton = screen.getByRole('button', { name: 'ログイン' });
+    
+    // First failed attempt
+    fireEvent.change(emailInput, { target: { value: 'invalid@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'wrongpassword' } });
+    fireEvent.click(submitButton);
+    
+    await waitFor(() => {
+      expect(screen.getByText('メールアドレスまたはパスワードが正しくありません。')).toBeInTheDocument();
+    });
+    
+    // Second successful attempt
+    fireEvent.change(emailInput, { target: { value: 'valid@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'correctpassword' } });
+    fireEvent.click(submitButton);
+    
+    await waitFor(() => {
+      expect(screen.queryByText('メールアドレスまたはパスワードが正しくありません。')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/components/ProtectedPage.test.tsx
+++ b/__tests__/components/ProtectedPage.test.tsx
@@ -1,0 +1,79 @@
+import { render } from '@testing-library/react';
+import { redirect } from 'next/navigation';
+import { auth } from '@/auth';
+import ProtectedPage from '@/components/ProtectedPage';
+
+// Mock next/navigation - redirect throws an error to stop execution
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn().mockImplementation((url: string) => {
+    throw new Error(`NEXT_REDIRECT: ${url}`);
+  }),
+}));
+
+// Mock auth
+jest.mock('@/auth', () => ({
+  auth: jest.fn(),
+}));
+
+const mockRedirect = redirect as jest.MockedFunction<typeof redirect>;
+const mockAuth = auth as jest.MockedFunction<typeof auth>;
+
+describe('ProtectedPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset redirect mock to its default behavior
+    mockRedirect.mockImplementation((url: string) => {
+      throw new Error(`NEXT_REDIRECT: ${url}`);
+    });
+  });
+
+  it('renders children when user is authenticated', async () => {
+    mockAuth.mockResolvedValue({
+      user: { id: '1', email: 'test@example.com', role: 'admin' },
+    } as any);
+
+    const TestComponent = () => <div>Protected Content</div>;
+    
+    const result = await ProtectedPage({ children: <TestComponent /> });
+    const { container } = render(result);
+    
+    expect(container.textContent).toBe('Protected Content');
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it('redirects to login when user is not authenticated', async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const TestComponent = () => <div>Protected Content</div>;
+    
+    await expect(async () => {
+      await ProtectedPage({ children: <TestComponent /> });
+    }).rejects.toThrow('NEXT_REDIRECT: /login');
+    
+    expect(mockRedirect).toHaveBeenCalledWith('/login');
+  });
+
+  it('redirects to login when session exists but user is null', async () => {
+    mockAuth.mockResolvedValue({ user: null } as any);
+
+    const TestComponent = () => <div>Protected Content</div>;
+    
+    await expect(async () => {
+      await ProtectedPage({ children: <TestComponent /> });
+    }).rejects.toThrow('NEXT_REDIRECT: /login');
+    
+    expect(mockRedirect).toHaveBeenCalledWith('/login');
+  });
+
+  it('redirects to login when session exists but user is undefined', async () => {
+    mockAuth.mockResolvedValue({ user: undefined } as any);
+
+    const TestComponent = () => <div>Protected Content</div>;
+    
+    await expect(async () => {
+      await ProtectedPage({ children: <TestComponent /> });
+    }).rejects.toThrow('NEXT_REDIRECT: /login');
+    
+    expect(mockRedirect).toHaveBeenCalledWith('/login');
+  });
+});

--- a/__tests__/components/SessionProvider.test.tsx
+++ b/__tests__/components/SessionProvider.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import NextAuthSessionProvider from '@/components/SessionProvider';
+import { Session } from 'next-auth';
+
+// Mock next-auth/react
+jest.mock('next-auth/react', () => ({
+  SessionProvider: ({ children, session }: { children: React.ReactNode; session?: Session | null }) => (
+    <div data-testid="session-provider" data-session={JSON.stringify(session)}>
+      {children}
+    </div>
+  ),
+}));
+
+describe('NextAuthSessionProvider', () => {
+  it('renders children without session', () => {
+    render(
+      <NextAuthSessionProvider>
+        <div>Test Child Component</div>
+      </NextAuthSessionProvider>
+    );
+    
+    expect(screen.getByText('Test Child Component')).toBeInTheDocument();
+    expect(screen.getByTestId('session-provider')).toBeInTheDocument();
+  });
+
+  it('renders children with session', () => {
+    const mockSession: Session = {
+      user: {
+        id: '1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'admin',
+      },
+      expires: '2025-12-31',
+    };
+
+    render(
+      <NextAuthSessionProvider session={mockSession}>
+        <div>Test Child Component</div>
+      </NextAuthSessionProvider>
+    );
+    
+    expect(screen.getByText('Test Child Component')).toBeInTheDocument();
+    expect(screen.getByTestId('session-provider')).toBeInTheDocument();
+    
+    const sessionProvider = screen.getByTestId('session-provider');
+    expect(sessionProvider).toHaveAttribute('data-session', JSON.stringify(mockSession));
+  });
+
+  it('renders children with null session', () => {
+    render(
+      <NextAuthSessionProvider session={null}>
+        <div>Test Child Component</div>
+      </NextAuthSessionProvider>
+    );
+    
+    expect(screen.getByText('Test Child Component')).toBeInTheDocument();
+    
+    const sessionProvider = screen.getByTestId('session-provider');
+    expect(sessionProvider).toHaveAttribute('data-session', 'null');
+  });
+
+  it('passes session prop to SessionProvider', () => {
+    const mockSession: Session = {
+      user: {
+        id: '2',
+        email: 'user@example.com',
+        name: 'Another User',
+        role: 'editor',
+      },
+      expires: '2025-06-30',
+    };
+
+    render(
+      <NextAuthSessionProvider session={mockSession}>
+        <span>Child content</span>
+      </NextAuthSessionProvider>
+    );
+    
+    const sessionProvider = screen.getByTestId('session-provider');
+    const sessionData = JSON.parse(sessionProvider.getAttribute('data-session') || '{}');
+    
+    expect(sessionData.user.email).toBe('user@example.com');
+    expect(sessionData.user.role).toBe('editor');
+  });
+
+  it('handles multiple children', () => {
+    render(
+      <NextAuthSessionProvider>
+        <div>First Child</div>
+        <div>Second Child</div>
+        <span>Third Child</span>
+      </NextAuthSessionProvider>
+    );
+    
+    expect(screen.getByText('First Child')).toBeInTheDocument();
+    expect(screen.getByText('Second Child')).toBeInTheDocument();
+    expect(screen.getByText('Third Child')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/Sidebar.test.tsx
+++ b/__tests__/components/Sidebar.test.tsx
@@ -1,0 +1,163 @@
+import { render, screen } from '@testing-library/react';
+import { usePathname } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import Sidebar from '@/components/Sidebar';
+
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+}));
+
+// Mock next-auth/react
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+}));
+
+// Mock lib/actions
+jest.mock('@/lib/actions', () => ({
+  logout: jest.fn(),
+}));
+
+const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>;
+const mockUseSession = useSession as jest.MockedFunction<typeof useSession>;
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    mockUsePathname.mockReturnValue('/dashboard');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders system title and logout button', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: { name: 'Test User', role: 'admin' },
+      },
+      status: 'authenticated',
+    });
+
+    render(<Sidebar />);
+    
+    expect(screen.getByText('広告管理システム')).toBeInTheDocument();
+    expect(screen.getByText('ログアウト')).toBeInTheDocument();
+  });
+
+  it('displays user name and role for admin', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: { name: '管理者太郎', role: 'admin' },
+      },
+      status: 'authenticated',
+    });
+
+    render(<Sidebar />);
+    
+    expect(screen.getByText('管理者太郎 (管理者)')).toBeInTheDocument();
+  });
+
+  it('displays user name and role for editor', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: { name: '編集者花子', role: 'editor' },
+      },
+      status: 'authenticated',
+    });
+
+    render(<Sidebar />);
+    
+    expect(screen.getByText('編集者花子 (編集者)')).toBeInTheDocument();
+  });
+
+  it('shows all menu items for admin user', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: { name: 'Admin User', role: 'admin' },
+      },
+      status: 'authenticated',
+    });
+
+    render(<Sidebar />);
+    
+    expect(screen.getByText('ダッシュボード')).toBeInTheDocument();
+    expect(screen.getByText('広告テンプレート')).toBeInTheDocument();
+    expect(screen.getByText('URLテンプレート')).toBeInTheDocument();
+    expect(screen.getByText('広告管理')).toBeInTheDocument();
+    expect(screen.getByText('記事と広告の紐付け')).toBeInTheDocument();
+    expect(screen.getByText('アカウント管理')).toBeInTheDocument();
+  });
+
+  it('shows limited menu items for editor user', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: { name: 'Editor User', role: 'editor' },
+      },
+      status: 'authenticated',
+    });
+
+    render(<Sidebar />);
+    
+    expect(screen.getByText('ダッシュボード')).toBeInTheDocument();
+    expect(screen.getByText('広告テンプレート')).toBeInTheDocument();
+    expect(screen.getByText('URLテンプレート')).toBeInTheDocument();
+    expect(screen.getByText('広告管理')).toBeInTheDocument();
+    expect(screen.getByText('記事と広告の紐付け')).toBeInTheDocument();
+    expect(screen.queryByText('アカウント管理')).not.toBeInTheDocument();
+  });
+
+  it('shows only dashboard for users without editor/admin role', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: { name: 'Regular User', role: 'user' },
+      },
+      status: 'authenticated',
+    });
+
+    render(<Sidebar />);
+    
+    expect(screen.getByText('ダッシュボード')).toBeInTheDocument();
+    expect(screen.queryByText('広告テンプレート')).not.toBeInTheDocument();
+    expect(screen.queryByText('アカウント管理')).not.toBeInTheDocument();
+  });
+
+  it('highlights active menu item based on pathname', () => {
+    mockUsePathname.mockReturnValue('/ad-templates');
+    mockUseSession.mockReturnValue({
+      data: {
+        user: { name: 'Test User', role: 'admin' },
+      },
+      status: 'authenticated',
+    });
+
+    render(<Sidebar />);
+    
+    const activeLink = screen.getByRole('link', { name: /広告テンプレート/ });
+    expect(activeLink).toHaveClass('bg-blue-600', 'text-white');
+  });
+
+  it('handles missing session gracefully', () => {
+    mockUseSession.mockReturnValue({
+      data: null,
+      status: 'unauthenticated',
+    });
+
+    render(<Sidebar />);
+    
+    expect(screen.getByText('広告管理システム')).toBeInTheDocument();
+    expect(screen.getByText('ダッシュボード')).toBeInTheDocument();
+  });
+
+  it('displays unknown role when role is undefined', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        user: { name: 'Test User' }, // role is undefined
+      },
+      status: 'authenticated',
+    });
+
+    render(<Sidebar />);
+    
+    expect(screen.getByText('Test User (不明)')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/TemplateForm.test.tsx
+++ b/__tests__/components/TemplateForm.test.tsx
@@ -1,0 +1,200 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import TemplateForm from '@/app/ad-templates/components/TemplateForm';
+import type { CreateAdTemplateRequest, AdTemplate } from '@/lib/definitions';
+
+// Mock HTMLCodeEditor
+jest.mock('@/components/HTMLCodeEditor', () => {
+  return jest.fn().mockImplementation(({ value, onChange, ...props }) => (
+    <textarea
+      data-testid="html-editor"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      {...props}
+    />
+  ));
+});
+
+// Mock ValidationGuide
+jest.mock('@/app/ad-templates/components/ValidationGuide', () => {
+  return jest.fn().mockImplementation(({ showNamingGuide, setShowNamingGuide }) => (
+    <div data-testid="validation-guide">
+      <button onClick={() => setShowNamingGuide(!showNamingGuide)}>
+        Toggle Guide
+      </button>
+    </div>
+  ));
+});
+
+// Mock template utils
+jest.mock('@/lib/template-utils', () => ({
+  extractPlaceholders: jest.fn(() => ['title']),
+  validatePlaceholderNaming: jest.fn(() => true),
+  addNofollowToLinks: jest.fn((html) => `${html} [with nofollow]`),
+  removeNofollowFromLinks: jest.fn((html) => html.replace(' [with nofollow]', '')),
+}));
+
+describe('TemplateForm', () => {
+  const mockSetFormData = jest.fn();
+  const mockSetAutoNofollow = jest.fn();
+  const mockSetShowNamingGuide = jest.fn();
+  const mockOnSubmit = jest.fn();
+  const mockOnCancel = jest.fn();
+  const mockAutoExtractPlaceholders = jest.fn();
+
+  const defaultFormData: CreateAdTemplateRequest = {
+    name: 'Test Template',
+    html: '<div>{{title}}</div>',
+    placeholders: ['title'],
+    description: 'Test description',
+  };
+
+  const defaultProps = {
+    formData: defaultFormData,
+    setFormData: mockSetFormData,
+    validationErrors: [],
+    autoNofollow: false,
+    setAutoNofollow: mockSetAutoNofollow,
+    showNamingGuide: false,
+    setShowNamingGuide: mockSetShowNamingGuide,
+    editingTemplate: null,
+    onSubmit: mockOnSubmit,
+    onCancel: mockOnCancel,
+    autoExtractPlaceholders: mockAutoExtractPlaceholders,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders form fields correctly', () => {
+    render(<TemplateForm {...defaultProps} />);
+    
+    expect(screen.getByDisplayValue('Test Template')).toBeInTheDocument();
+    expect(screen.getByTestId('html-editor')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Test description')).toBeInTheDocument();
+    expect(screen.getByText('作成')).toBeInTheDocument();
+    expect(screen.getByText('キャンセル')).toBeInTheDocument();
+  });
+
+  it('shows edit mode when editing template', () => {
+    const editingTemplate: AdTemplate = {
+      id: 1,
+      name: 'Existing Template',
+      html: '<div>existing</div>',
+      placeholders: [],
+      description: 'Existing description',
+    };
+
+    render(<TemplateForm {...defaultProps} editingTemplate={editingTemplate} />);
+    
+    expect(screen.getByText('テンプレートを編集')).toBeInTheDocument();
+    expect(screen.getByText('更新')).toBeInTheDocument();
+  });
+
+  it('calls onSubmit when form is submitted', () => {
+    render(<TemplateForm {...defaultProps} />);
+    
+    const form = screen.getByRole('button', { name: '作成' }).closest('form');
+    fireEvent.submit(form!);
+    
+    expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when cancel button is clicked', () => {
+    render(<TemplateForm {...defaultProps} />);
+    
+    fireEvent.click(screen.getByText('キャンセル'));
+    
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates template name when input changes', () => {
+    render(<TemplateForm {...defaultProps} />);
+    
+    const nameInput = screen.getByDisplayValue('Test Template');
+    fireEvent.change(nameInput, { target: { value: 'New Template Name' } });
+    
+    expect(mockSetFormData).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('updates HTML when editor changes', () => {
+    render(<TemplateForm {...defaultProps} />);
+    
+    const htmlEditor = screen.getByTestId('html-editor');
+    fireEvent.change(htmlEditor, { target: { value: '<div>New HTML</div>' } });
+    
+    expect(mockSetFormData).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('adds new placeholder when add button is clicked', () => {
+    render(<TemplateForm {...defaultProps} />);
+    
+    fireEvent.click(screen.getByText('プレースホルダーを追加'));
+    
+    expect(mockSetFormData).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('removes placeholder when delete button is clicked', () => {
+    render(<TemplateForm {...defaultProps} />);
+    
+    const deleteButtons = screen.getAllByText('削除');
+    fireEvent.click(deleteButtons[0]);
+    
+    expect(mockSetFormData).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('toggles autoNofollow when checkbox is clicked', () => {
+    render(<TemplateForm {...defaultProps} />);
+    
+    const checkbox = screen.getByLabelText('自動nofollow追加');
+    fireEvent.click(checkbox);
+    
+    expect(mockSetAutoNofollow).toHaveBeenCalledWith(true);
+  });
+
+  it('shows validation errors when present', () => {
+    const propsWithErrors = {
+      ...defaultProps,
+      validationErrors: ['Error 1', 'Error 2'],
+    };
+    
+    render(<TemplateForm {...propsWithErrors} />);
+    
+    expect(screen.getByText('Error 1')).toBeInTheDocument();
+    expect(screen.getByText('Error 2')).toBeInTheDocument();
+  });
+
+  it('disables submit button when validation errors exist', () => {
+    const propsWithErrors = {
+      ...defaultProps,
+      validationErrors: ['Error 1'],
+    };
+    
+    render(<TemplateForm {...propsWithErrors} />);
+    
+    const submitButton = screen.getByText('作成');
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('calls autoExtractPlaceholders when auto-fix button is clicked', () => {
+    const propsWithErrors = {
+      ...defaultProps,
+      validationErrors: ['Error 1'],
+    };
+    
+    render(<TemplateForm {...propsWithErrors} />);
+    
+    fireEvent.click(screen.getByText('自動修正'));
+    
+    expect(mockAutoExtractPlaceholders).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates description when textarea changes', () => {
+    render(<TemplateForm {...defaultProps} />);
+    
+    const descriptionTextarea = screen.getByDisplayValue('Test description');
+    fireEvent.change(descriptionTextarea, { target: { value: 'New description' } });
+    
+    expect(mockSetFormData).toHaveBeenCalledWith(expect.any(Function));
+  });
+});

--- a/__tests__/components/TemplateList.test.tsx
+++ b/__tests__/components/TemplateList.test.tsx
@@ -1,0 +1,199 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import TemplateList from '@/app/ad-templates/components/TemplateList';
+import type { AdTemplate } from '@/lib/definitions';
+
+// Mock template utils
+jest.mock('@/lib/template-utils', () => ({
+  getSampleValue: jest.fn((placeholder) => `Sample ${placeholder}`),
+}));
+
+describe('TemplateList', () => {
+  const mockOnEdit = jest.fn();
+  const mockOnDelete = jest.fn();
+  const mockOnCreateClick = jest.fn();
+
+  const mockTemplates: AdTemplate[] = [
+    {
+      id: 1,
+      name: 'Template 1',
+      html: '<div>{{title}}</div>',
+      placeholders: ['title'],
+      description: 'Description 1',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    },
+    {
+      id: 2,
+      name: 'Template 2',
+      html: '<div><h2>{{title}}</h2><img src="{{imageUrl}}" /></div>',
+      placeholders: ['title', 'imageUrl'],
+      description: 'Description 2',
+      created_at: '2024-01-02T00:00:00Z',
+      updated_at: '2024-01-02T00:00:00Z',
+    },
+  ];
+
+  const defaultProps = {
+    templates: mockTemplates,
+    onEdit: mockOnEdit,
+    onDelete: mockOnDelete,
+    onCreateClick: mockOnCreateClick,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders empty state when no templates', () => {
+    const propsWithEmptyList = {
+      ...defaultProps,
+      templates: [],
+    };
+    
+    render(<TemplateList {...propsWithEmptyList} />);
+    
+    expect(screen.getByText('テンプレートがありません')).toBeInTheDocument();
+    expect(screen.getByText('広告テンプレートを作成して始めましょう')).toBeInTheDocument();
+    expect(screen.getByText('最初のテンプレートを作成')).toBeInTheDocument();
+  });
+
+  it('calls onCreateClick when create button is clicked in empty state', () => {
+    const propsWithEmptyList = {
+      ...defaultProps,
+      templates: [],
+    };
+    
+    render(<TemplateList {...propsWithEmptyList} />);
+    
+    fireEvent.click(screen.getByText('最初のテンプレートを作成'));
+    
+    expect(mockOnCreateClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders list of templates', () => {
+    render(<TemplateList {...defaultProps} />);
+    
+    expect(screen.getByText('Template 1')).toBeInTheDocument();
+    expect(screen.getByText('Template 2')).toBeInTheDocument();
+    expect(screen.getByText('Description 1')).toBeInTheDocument();
+    expect(screen.getByText('Description 2')).toBeInTheDocument();
+  });
+
+  it('displays placeholders for each template', () => {
+    render(<TemplateList {...defaultProps} />);
+    
+    // Template 1 has 'title' placeholder
+    expect(screen.getByText('プレースホルダー: title')).toBeInTheDocument();
+    
+    // Template 2 has 'title' and 'imageUrl' placeholders
+    expect(screen.getByText('プレースホルダー: title, imageUrl')).toBeInTheDocument();
+  });
+
+  it('calls onEdit when edit button is clicked', () => {
+    render(<TemplateList {...defaultProps} />);
+    
+    const editButtons = screen.getAllByText('編集');
+    fireEvent.click(editButtons[0]);
+    
+    expect(mockOnEdit).toHaveBeenCalledWith(mockTemplates[0]);
+  });
+
+  it('calls onDelete when delete button is clicked', () => {
+    render(<TemplateList {...defaultProps} />);
+    
+    const deleteButtons = screen.getAllByText('削除');
+    fireEvent.click(deleteButtons[0]);
+    
+    expect(mockOnDelete).toHaveBeenCalledWith(1);
+  });
+
+  it('displays basic template information', () => {
+    render(<TemplateList {...defaultProps} />);
+    
+    // Just check that templates and their basic info are displayed
+    expect(screen.getByText('Template 1')).toBeInTheDocument();
+    expect(screen.getByText('Template 2')).toBeInTheDocument();
+    expect(screen.getByText('Description 1')).toBeInTheDocument();
+    expect(screen.getByText('Description 2')).toBeInTheDocument();
+  });
+
+  it('renders template previews with sample values', () => {
+    render(<TemplateList {...defaultProps} />);
+    
+    // The preview should contain replaced placeholder values
+    expect(screen.getAllByText('Sample title')).toHaveLength(2);
+    // Sample imageUrl appears as img src attribute, not as text content
+    const images = document.querySelectorAll('img[src="Sample imageUrl"]');
+    expect(images.length).toBeGreaterThan(0);
+  });
+
+  it('handles templates without description', () => {
+    const templatesWithoutDescription = [
+      {
+        ...mockTemplates[0],
+        description: '',
+      },
+    ];
+    
+    const propsWithoutDescription = {
+      ...defaultProps,
+      templates: templatesWithoutDescription,
+    };
+    
+    render(<TemplateList {...propsWithoutDescription} />);
+    
+    expect(screen.getByText('Template 1')).toBeInTheDocument();
+    // Should not crash when description is empty
+  });
+
+  it('handles templates without placeholders', () => {
+    const templatesWithoutPlaceholders = [
+      {
+        ...mockTemplates[0],
+        html: '<div>Static HTML</div>',
+        placeholders: [],
+      },
+    ];
+    
+    const propsWithoutPlaceholders = {
+      ...defaultProps,
+      templates: templatesWithoutPlaceholders,
+    };
+    
+    render(<TemplateList {...propsWithoutPlaceholders} />);
+    
+    expect(screen.getByText('Template 1')).toBeInTheDocument();
+    // When no placeholders, just shows "プレースホルダー: " with empty string
+    expect(screen.getByText('プレースホルダー:')).toBeInTheDocument();
+  });
+
+  it('shows proper action buttons for each template', () => {
+    render(<TemplateList {...defaultProps} />);
+    
+    const editButtons = screen.getAllByText('編集');
+    const deleteButtons = screen.getAllByText('削除');
+    
+    expect(editButtons).toHaveLength(2);
+    expect(deleteButtons).toHaveLength(2);
+  });
+
+  it('handles templates with undefined dates gracefully', () => {
+    const templatesWithUndefinedDates = [
+      {
+        ...mockTemplates[0],
+        created_at: undefined,
+        updated_at: undefined,
+      },
+    ];
+    
+    const propsWithUndefinedDates = {
+      ...defaultProps,
+      templates: templatesWithUndefinedDates,
+    };
+    
+    render(<TemplateList {...propsWithUndefinedDates} />);
+    
+    expect(screen.getByText('Template 1')).toBeInTheDocument();
+    // Should not crash when dates are undefined
+  });
+});

--- a/__tests__/components/TemplatePreview.test.tsx
+++ b/__tests__/components/TemplatePreview.test.tsx
@@ -1,0 +1,190 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import TemplatePreview from '@/app/ad-templates/components/TemplatePreview';
+import type { CreateAdTemplateRequest } from '@/lib/definitions';
+
+// Mock template utils
+jest.mock('@/lib/template-utils', () => ({
+  getSampleValue: jest.fn((placeholder) => `Sample ${placeholder}`),
+  sanitizeLinksForPreview: jest.fn((html) => html),
+}));
+
+describe('TemplatePreview', () => {
+  const mockSetPreviewMode = jest.fn();
+  const mockSetPreviewSize = jest.fn();
+  const mockUpdateCustomValue = jest.fn();
+
+  const defaultFormData: CreateAdTemplateRequest = {
+    name: 'Test Template',
+    html: '<div class="ad-banner"><h2>{{title}}</h2><img src="{{imageUrl}}" /></div>',
+    placeholders: ['title', 'imageUrl'],
+    description: 'Test description',
+  };
+
+  const defaultProps = {
+    formData: defaultFormData,
+    previewMode: 'sample' as const,
+    customValues: {},
+    previewSize: 'desktop' as const,
+    setPreviewMode: mockSetPreviewMode,
+    setPreviewSize: mockSetPreviewSize,
+    updateCustomValue: mockUpdateCustomValue,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders preview section', () => {
+    render(<TemplatePreview {...defaultProps} />);
+    
+    expect(screen.getByText('プレビュー')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no HTML provided', () => {
+    const propsWithEmptyHTML = {
+      ...defaultProps,
+      formData: { ...defaultFormData, html: '' },
+    };
+    
+    render(<TemplatePreview {...propsWithEmptyHTML} />);
+    
+    expect(screen.getByText('HTMLコードを入力するとプレビューが表示されます')).toBeInTheDocument();
+  });
+
+  it('renders preview mode toggle buttons', () => {
+    render(<TemplatePreview {...defaultProps} />);
+    
+    expect(screen.getByText('サンプル値')).toBeInTheDocument();
+    expect(screen.getByText('カスタム値')).toBeInTheDocument();
+  });
+
+  it('renders preview size toggle buttons', () => {
+    render(<TemplatePreview {...defaultProps} />);
+    
+    expect(screen.getByText('🖥️')).toBeInTheDocument(); // Desktop
+    expect(screen.getByText('📱')).toBeInTheDocument(); // Mobile
+  });
+
+  it('calls setPreviewMode when mode button is clicked', () => {
+    render(<TemplatePreview {...defaultProps} />);
+    
+    fireEvent.click(screen.getByText('カスタム値'));
+    
+    expect(mockSetPreviewMode).toHaveBeenCalledWith('custom');
+  });
+
+  it('calls setPreviewSize when size button is clicked', () => {
+    render(<TemplatePreview {...defaultProps} />);
+    
+    fireEvent.click(screen.getByText('📱'));
+    
+    expect(mockSetPreviewSize).toHaveBeenCalledWith('mobile');
+  });
+
+  it('shows custom value inputs when in custom mode', () => {
+    const propsWithCustomMode = {
+      ...defaultProps,
+      previewMode: 'custom' as const,
+    };
+    
+    render(<TemplatePreview {...propsWithCustomMode} />);
+    
+    expect(screen.getByText('カスタム値を入力')).toBeInTheDocument();
+    expect(screen.getByLabelText('title')).toBeInTheDocument();
+    expect(screen.getByLabelText('imageUrl')).toBeInTheDocument();
+  });
+
+  it('calls updateCustomValue when custom input changes', () => {
+    const propsWithCustomMode = {
+      ...defaultProps,
+      previewMode: 'custom' as const,
+    };
+    
+    render(<TemplatePreview {...propsWithCustomMode} />);
+    
+    const titleInput = screen.getByLabelText('title');
+    fireEvent.change(titleInput, { target: { value: 'Custom Title' } });
+    
+    expect(mockUpdateCustomValue).toHaveBeenCalledWith('title', 'Custom Title');
+  });
+
+  it('highlights active preview mode button', () => {
+    render(<TemplatePreview {...defaultProps} />);
+    
+    const sampleButton = screen.getByText('サンプル値');
+    expect(sampleButton).toHaveClass('bg-blue-600', 'text-white');
+    
+    const customButton = screen.getByText('カスタム値');
+    expect(customButton).toHaveClass('bg-gray-100');
+  });
+
+  it('highlights active preview size button', () => {
+    render(<TemplatePreview {...defaultProps} />);
+    
+    const desktopButton = screen.getByText('🖥️');
+    expect(desktopButton).toHaveClass('bg-green-600', 'text-white');
+  });
+
+  it('applies correct size classes for mobile preview', () => {
+    const propsWithMobileSize = {
+      ...defaultProps,
+      previewSize: 'mobile' as const,
+    };
+    
+    render(<TemplatePreview {...propsWithMobileSize} />);
+    
+    // Check that the mobile button is active
+    const mobileButton = screen.getByRole('button', { name: '📱' });
+    expect(mobileButton).toHaveClass('bg-green-600', 'text-white');
+    
+    // Check that desktop button is not active 
+    const desktopButton = screen.getByRole('button', { name: '🖥️' });
+    expect(desktopButton).toHaveClass('bg-gray-100', 'text-gray-700');
+  });
+
+  it('shows placeholder values in custom inputs', () => {
+    const propsWithCustomMode = {
+      ...defaultProps,
+      previewMode: 'custom' as const,
+    };
+    
+    render(<TemplatePreview {...propsWithCustomMode} />);
+    
+    const titleInput = screen.getByLabelText('title');
+    expect(titleInput).toHaveAttribute('placeholder', 'Sample title');
+    
+    const imageUrlInput = screen.getByLabelText('imageUrl');
+    expect(imageUrlInput).toHaveAttribute('placeholder', 'Sample imageUrl');
+  });
+
+  it('displays custom values in inputs when provided', () => {
+    const propsWithCustomValues = {
+      ...defaultProps,
+      previewMode: 'custom' as const,
+      customValues: {
+        title: 'My Custom Title',
+        imageUrl: 'custom-image.jpg',
+      },
+    };
+    
+    render(<TemplatePreview {...propsWithCustomValues} />);
+    
+    const titleInput = screen.getByDisplayValue('My Custom Title');
+    expect(titleInput).toBeInTheDocument();
+    
+    const imageUrlInput = screen.getByDisplayValue('custom-image.jpg');
+    expect(imageUrlInput).toBeInTheDocument();
+  });
+
+  it('does not show custom inputs when no placeholders exist', () => {
+    const propsWithNoPlaceholders = {
+      ...defaultProps,
+      previewMode: 'custom' as const,
+      formData: { ...defaultFormData, placeholders: [] },
+    };
+    
+    render(<TemplatePreview {...propsWithNoPlaceholders} />);
+    
+    expect(screen.queryByText('カスタム値を入力')).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/UserForm.test.tsx
+++ b/__tests__/components/UserForm.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import UserForm from '@/app/accounts/components/UserForm';
+import type { User } from '@/lib/definitions';
+
+// Mock user actions
+jest.mock('@/lib/user-actions', () => ({
+  createUser: jest.fn(),
+  updateUser: jest.fn(),
+}));
+
+// Mock useActionState
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useActionState: jest.fn((action, initialState) => [initialState, action]),
+}));
+
+describe('UserForm', () => {
+  const mockOnClose = jest.fn();
+  const mockOnSuccess = jest.fn();
+
+  const defaultProps = {
+    onClose: mockOnClose,
+    onSuccess: mockOnSuccess,
+  };
+
+  const mockUser: User = {
+    id: 1,
+    name: 'Test User',
+    email: 'test@example.com',
+    password: 'hashedpassword',
+    role: 'editor' as const,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders create user form when no user is provided', () => {
+    render(<UserForm {...defaultProps} />);
+    
+    expect(screen.getByText('新しいユーザーを追加')).toBeInTheDocument();
+    expect(screen.getByLabelText('名前')).toBeInTheDocument();
+    expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument();
+    expect(screen.getByLabelText('パスワード')).toBeInTheDocument();
+    // Role is a hidden field in the component
+    expect(screen.getByText('作成')).toBeInTheDocument();
+    expect(screen.getByText('キャンセル')).toBeInTheDocument();
+  });
+
+  it('renders edit user form when user is provided', () => {
+    const propsWithUser = {
+      ...defaultProps,
+      user: mockUser,
+    };
+    
+    render(<UserForm {...propsWithUser} />);
+    
+    expect(screen.getByText('ユーザー編集')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Test User')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('test@example.com')).toBeInTheDocument();
+    expect(screen.getByText('更新')).toBeInTheDocument();
+  });
+
+  it('has proper form field attributes', () => {
+    render(<UserForm {...defaultProps} />);
+    
+    const nameInput = screen.getByLabelText('名前');
+    const emailInput = screen.getByLabelText('メールアドレス');
+    const passwordInput = screen.getByLabelText('パスワード');
+    
+    expect(nameInput).toHaveAttribute('type', 'text');
+    expect(nameInput).toHaveAttribute('name', 'name');
+    expect(nameInput).toBeRequired();
+    
+    expect(emailInput).toHaveAttribute('type', 'email');
+    expect(emailInput).toHaveAttribute('name', 'email');
+    expect(emailInput).toBeRequired();
+    
+    expect(passwordInput).toHaveAttribute('type', 'password');
+    expect(passwordInput).toHaveAttribute('name', 'password');
+    expect(passwordInput).toBeRequired();
+  });
+
+  it('has hidden role field set to editor', () => {
+    render(<UserForm {...defaultProps} />);
+    
+    const roleInput = screen.getByDisplayValue('editor');
+    expect(roleInput).toHaveAttribute('type', 'hidden');
+    expect(roleInput).toHaveAttribute('name', 'role');
+  });
+
+  it('calls onClose when cancel button is clicked', () => {
+    render(<UserForm {...defaultProps} />);
+    
+    fireEvent.click(screen.getByText('キャンセル'));
+    
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates form values when inputs change', () => {
+    render(<UserForm {...defaultProps} />);
+    
+    const nameInput = screen.getByLabelText('名前');
+    const emailInput = screen.getByLabelText('メールアドレス');
+    
+    fireEvent.change(nameInput, { target: { value: 'New Name' } });
+    fireEvent.change(emailInput, { target: { value: 'new@example.com' } });
+    
+    expect(nameInput).toHaveValue('New Name');
+    expect(emailInput).toHaveValue('new@example.com');
+  });
+
+  it('includes hidden id field when editing user', () => {
+    const propsWithUser = {
+      ...defaultProps,
+      user: mockUser,
+    };
+    
+    render(<UserForm {...propsWithUser} />);
+    
+    const hiddenIdInput = screen.getByDisplayValue('1');
+    expect(hiddenIdInput).toHaveAttribute('type', 'hidden');
+    expect(hiddenIdInput).toHaveAttribute('name', 'id');
+  });
+
+  it('shows password as optional when editing user', () => {
+    const propsWithUser = {
+      ...defaultProps,
+      user: mockUser,
+    };
+    
+    render(<UserForm {...propsWithUser} />);
+    
+    const passwordInput = screen.getByLabelText(/パスワード.*変更する場合のみ/);
+    expect(passwordInput).not.toBeRequired();
+  });
+
+  it('has modal overlay styling', () => {
+    render(<UserForm {...defaultProps} />);
+    
+    const modalOverlay = screen.getByText('新しいユーザーを追加').closest('div')?.parentElement;
+    expect(modalOverlay).toHaveClass('fixed', 'inset-0', 'bg-black', 'bg-opacity-50');
+  });
+
+  it('displays form validation state correctly', () => {
+    // Mock useActionState to return an error state
+    const mockUseActionState = jest.requireMock('react').useActionState;
+    mockUseActionState.mockReturnValue([
+      { message: 'Email already exists', success: false },
+      jest.fn()
+    ]);
+    
+    render(<UserForm {...defaultProps} />);
+    
+    expect(screen.getByText('Email already exists')).toBeInTheDocument();
+  });
+
+  it('always sets role to editor in hidden field', () => {
+    const propsWithUser = {
+      ...defaultProps,
+      user: mockUser,
+    };
+    
+    render(<UserForm {...propsWithUser} />);
+    
+    // Role is always set to 'editor' via hidden input
+    const roleInput = screen.getByDisplayValue('editor');
+    expect(roleInput).toHaveAttribute('type', 'hidden');
+    expect(roleInput).toHaveAttribute('name', 'role');
+  });
+});

--- a/__tests__/components/UserList.test.tsx
+++ b/__tests__/components/UserList.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import UserList from '@/app/accounts/components/UserList';
+import type { User } from '@/lib/definitions';
+
+describe('UserList', () => {
+  const mockOnEdit = jest.fn();
+  const mockOnDelete = jest.fn();
+  const mockOnAddUser = jest.fn();
+
+  const mockUsers: User[] = [
+    {
+      id: 1,
+      name: 'Admin User',
+      email: 'admin@example.com',
+      password: 'hashedpassword',
+      role: 'admin',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    },
+    {
+      id: 2,
+      name: 'Editor User',
+      email: 'editor@example.com',
+      password: 'hashedpassword',
+      role: 'editor',
+      created_at: '2024-01-02T00:00:00Z',
+      updated_at: '2024-01-02T00:00:00Z',
+    },
+  ];
+
+  const defaultProps = {
+    users: mockUsers,
+    loading: false,
+    currentUserId: 1,
+    onEdit: mockOnEdit,
+    onDelete: mockOnDelete,
+    onAddUser: mockOnAddUser,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders user list with header and add button', () => {
+    render(<UserList {...defaultProps} />);
+    
+    expect(screen.getByText('アカウント管理')).toBeInTheDocument();
+    expect(screen.getByText('新しいアカウントを追加')).toBeInTheDocument();
+  });
+
+  it('calls onAddUser when add button is clicked', () => {
+    render(<UserList {...defaultProps} />);
+    
+    fireEvent.click(screen.getByText('新しいアカウントを追加'));
+    
+    expect(mockOnAddUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('displays loading state', () => {
+    const propsWithLoading = {
+      ...defaultProps,
+      loading: true,
+    };
+    
+    render(<UserList {...propsWithLoading} />);
+    
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('displays empty state when no users', () => {
+    const propsWithEmptyList = {
+      ...defaultProps,
+      users: [],
+    };
+    
+    render(<UserList {...propsWithEmptyList} />);
+    
+    expect(screen.getByText('ユーザーがいません')).toBeInTheDocument();
+    expect(screen.getByText('新しいアカウントを追加してください')).toBeInTheDocument();
+  });
+
+  it('renders user information correctly', () => {
+    render(<UserList {...defaultProps} />);
+    
+    expect(screen.getByText('Admin User')).toBeInTheDocument();
+    expect(screen.getByText('admin@example.com')).toBeInTheDocument();
+    expect(screen.getByText('Editor User')).toBeInTheDocument();
+    expect(screen.getByText('editor@example.com')).toBeInTheDocument();
+  });
+
+  it('displays role badges with correct colors', () => {
+    render(<UserList {...defaultProps} />);
+    
+    const adminBadge = screen.getByText('管理者');
+    const editorBadge = screen.getByText('編集者');
+    
+    expect(adminBadge).toHaveClass('bg-red-100', 'text-red-800');
+    expect(editorBadge).toHaveClass('bg-blue-100', 'text-blue-800');
+  });
+
+  it('calls onEdit when edit button is clicked', () => {
+    render(<UserList {...defaultProps} />);
+    
+    const editButtons = screen.getAllByText('編集');
+    fireEvent.click(editButtons[0]);
+    
+    expect(mockOnEdit).toHaveBeenCalledWith(mockUsers[0]);
+  });
+
+  it('calls onDelete when delete button is clicked', () => {
+    render(<UserList {...defaultProps} />);
+    
+    const deleteButtons = screen.getAllByText('削除');
+    fireEvent.click(deleteButtons[0]);
+    
+    expect(mockOnDelete).toHaveBeenCalledWith(2);
+  });
+
+  it('hides delete button for current admin user', () => {
+    render(<UserList {...defaultProps} />);
+    
+    const deleteButtons = screen.getAllByText('削除');
+    
+    // Only one delete button should be visible since first user is admin and current user
+    expect(deleteButtons).toHaveLength(1);
+  });
+
+  it('shows delete button for non-current users', () => {
+    render(<UserList {...defaultProps} />);
+    
+    // Second user (editor, not current user) should have delete button
+    const deleteButtons = screen.getAllByText('削除');
+    expect(deleteButtons).toHaveLength(1);
+  });
+
+  it('displays creation dates correctly', () => {
+    render(<UserList {...defaultProps} />);
+    
+    expect(screen.getByText('2024/1/1')).toBeInTheDocument();
+    expect(screen.getByText('2024/1/2')).toBeInTheDocument();
+  });
+
+  it('handles users with undefined dates gracefully', () => {
+    const usersWithUndefinedDates = [
+      {
+        ...mockUsers[0],
+        created_at: undefined,
+      },
+    ];
+    
+    const propsWithUndefinedDates = {
+      ...defaultProps,
+      users: usersWithUndefinedDates,
+    };
+    
+    render(<UserList {...propsWithUndefinedDates} />);
+    
+    expect(screen.getByText('Admin User')).toBeInTheDocument();
+    // Should not crash when date is undefined
+  });
+
+  it('shows table headers correctly', () => {
+    render(<UserList {...defaultProps} />);
+    
+    expect(screen.getByText('ユーザー')).toBeInTheDocument();
+    expect(screen.getByText('役割')).toBeInTheDocument();
+    expect(screen.getByText('作成日')).toBeInTheDocument();
+    expect(screen.getByText('操作')).toBeInTheDocument();
+  });
+
+  it('renders correct number of user rows', () => {
+    render(<UserList {...defaultProps} />);
+    
+    // Should have 2 user rows plus header row
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(3); // 1 header + 2 data rows
+  });
+
+  it('handles single user correctly', () => {
+    const propsWithSingleUser = {
+      ...defaultProps,
+      users: [mockUsers[0]],
+    };
+    
+    render(<UserList {...propsWithSingleUser} />);
+    
+    expect(screen.getByText('Admin User')).toBeInTheDocument();
+    expect(screen.queryByText('Editor User')).not.toBeInTheDocument();
+    
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(2); // 1 header + 1 data row
+  });
+});

--- a/__tests__/components/ValidationGuide.test.tsx
+++ b/__tests__/components/ValidationGuide.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ValidationGuide from '@/app/ad-templates/components/ValidationGuide';
+
+describe('ValidationGuide', () => {
+  const mockSetShowNamingGuide = jest.fn();
+
+  const defaultProps = {
+    showNamingGuide: false,
+    setShowNamingGuide: mockSetShowNamingGuide,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders validation guide header', () => {
+    render(<ValidationGuide {...defaultProps} />);
+    
+    expect(screen.getByText('プレースホルダー命名規則')).toBeInTheDocument();
+    expect(screen.getByText('表示する')).toBeInTheDocument();
+  });
+
+  it('calls setShowNamingGuide when toggle button is clicked', () => {
+    render(<ValidationGuide {...defaultProps} />);
+    
+    fireEvent.click(screen.getByText('表示する'));
+    
+    expect(mockSetShowNamingGuide).toHaveBeenCalledWith(true);
+  });
+
+  it('calls setShowNamingGuide when header is clicked', () => {
+    render(<ValidationGuide {...defaultProps} />);
+    
+    const header = screen.getByText('プレースホルダー命名規則').closest('div');
+    fireEvent.click(header!);
+    
+    expect(mockSetShowNamingGuide).toHaveBeenCalledWith(true);
+  });
+
+  it('shows "非表示にする" when guide is visible', () => {
+    const propsWithVisibleGuide = {
+      ...defaultProps,
+      showNamingGuide: true,
+    };
+    
+    render(<ValidationGuide {...propsWithVisibleGuide} />);
+    
+    expect(screen.getByText('非表示にする')).toBeInTheDocument();
+  });
+
+  it('displays all category sections when guide is visible', () => {
+    const propsWithVisibleGuide = {
+      ...defaultProps,
+      showNamingGuide: true,
+    };
+    
+    render(<ValidationGuide {...propsWithVisibleGuide} />);
+    
+    // Check main sections are visible
+    expect(screen.getByText('プレースホルダー命名規則')).toBeInTheDocument();
+    expect(screen.getByText('プレースホルダー例とサンプル出力')).toBeInTheDocument();
+    
+    // Check for some key categories - using getAllByText since they appear multiple times
+    expect(screen.getAllByText('画像').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('URL').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('タイトル').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('説明文').length).toBeGreaterThan(0);
+  });
+
+  it('displays keyword tags in each category when guide is visible', () => {
+    const propsWithVisibleGuide = {
+      ...defaultProps,
+      showNamingGuide: true,
+    };
+    
+    render(<ValidationGuide {...propsWithVisibleGuide} />);
+    
+    // Check some specific keyword tags
+    expect(screen.getByText('Image')).toBeInTheDocument();
+    expect(screen.getByText('Url')).toBeInTheDocument();
+    expect(screen.getByText('Title')).toBeInTheDocument();
+    expect(screen.getByText('Description')).toBeInTheDocument();
+    expect(screen.getByText('Price')).toBeInTheDocument();
+    expect(screen.getByText('Button')).toBeInTheDocument();
+  });
+
+  it('shows hint text when guide is visible', () => {
+    const propsWithVisibleGuide = {
+      ...defaultProps,
+      showNamingGuide: true,
+    };
+    
+    render(<ValidationGuide {...propsWithVisibleGuide} />);
+    
+    expect(screen.getByText('💡 ヒント:')).toBeInTheDocument();
+    expect(screen.getByText(/これらのキーワードを含む名前を使用すると/)).toBeInTheDocument();
+  });
+
+  it('displays detailed examples table when guide is visible', () => {
+    const propsWithVisibleGuide = {
+      ...defaultProps,
+      showNamingGuide: true,
+    };
+    
+    render(<ValidationGuide {...propsWithVisibleGuide} />);
+    
+    expect(screen.getByText('プレースホルダー例とサンプル出力')).toBeInTheDocument();
+    expect(screen.getByText('カテゴリ')).toBeInTheDocument();
+    expect(screen.getByText('プレースホルダー例')).toBeInTheDocument();
+    expect(screen.getByText('サンプル出力')).toBeInTheDocument();
+  });
+
+  it('shows specific placeholder examples in table when guide is visible', () => {
+    const propsWithVisibleGuide = {
+      ...defaultProps,
+      showNamingGuide: true,
+    };
+    
+    render(<ValidationGuide {...propsWithVisibleGuide} />);
+    
+    // Check some specific placeholder examples
+    expect(screen.getByText('productImage')).toBeInTheDocument();
+    expect(screen.getByText('productUrl')).toBeInTheDocument();
+    expect(screen.getByText('productTitle')).toBeInTheDocument();
+    expect(screen.getByText('ctaButton')).toBeInTheDocument();
+  });
+
+  it('shows sample output values in table when guide is visible', () => {
+    const propsWithVisibleGuide = {
+      ...defaultProps,
+      showNamingGuide: true,
+    };
+    
+    render(<ValidationGuide {...propsWithVisibleGuide} />);
+    
+    // Check sample output values - need to handle the exact URL
+    expect(screen.getByText('#')).toBeInTheDocument();
+    expect(screen.getByText('サンプルタイトル')).toBeInTheDocument();
+    expect(screen.getByText('無料')).toBeInTheDocument();
+    expect(screen.getByText('今すぐ登録')).toBeInTheDocument();
+    expect(screen.getByText('🚀')).toBeInTheDocument();
+  });
+
+  it('does not show guide content when showNamingGuide is false', () => {
+    render(<ValidationGuide {...defaultProps} />);
+    
+    expect(screen.queryByText('画像')).not.toBeInTheDocument();
+    expect(screen.queryByText('プレースホルダー例とサンプル出力')).not.toBeInTheDocument();
+    expect(screen.queryByText('💡 ヒント:')).not.toBeInTheDocument();
+  });
+
+  it('has proper styling classes for blue theme', () => {
+    const propsWithVisibleGuide = {
+      ...defaultProps,
+      showNamingGuide: true,
+    };
+    
+    render(<ValidationGuide {...propsWithVisibleGuide} />);
+    
+    const header = screen.getByText('プレースホルダー命名規則');
+    expect(header).toHaveClass('text-blue-900');
+    
+    const toggleButton = screen.getByText('非表示にする');
+    expect(toggleButton).toHaveClass('text-blue-600');
+  });
+});

--- a/__tests__/hooks/useTemplates.test.tsx
+++ b/__tests__/hooks/useTemplates.test.tsx
@@ -1,0 +1,282 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useTemplates } from '@/app/ad-templates/hooks/useTemplates';
+import type { AdTemplate, CreateAdTemplateRequest } from '@/lib/definitions';
+
+// Mock fetch
+global.fetch = jest.fn();
+
+// Mock addNofollowToLinks
+jest.mock('@/lib/template-utils', () => ({
+  addNofollowToLinks: jest.fn((html) => `${html} with nofollow`),
+}));
+
+const mockFetch = fetch as jest.MockedFunction<typeof fetch>;
+
+describe('useTemplates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockTemplates: AdTemplate[] = [
+    {
+      id: 1,
+      name: 'Template 1',
+      html: '<div>Test 1</div>',
+      placeholders: ['title'],
+      description: 'Description 1',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    },
+    {
+      id: 2,
+      name: 'Template 2',
+      html: '<div>Test 2</div>',
+      placeholders: ['title', 'content'],
+      description: 'Description 2',
+      created_at: '2024-01-02T00:00:00Z',
+      updated_at: '2024-01-02T00:00:00Z',
+    },
+  ];
+
+  it('fetches templates on mount and sorts by updated_at', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockTemplates),
+    } as Response);
+
+    const { result } = renderHook(() => useTemplates());
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.templates).toHaveLength(2);
+    expect(result.current.templates[0].id).toBe(2); // Template 2 is more recent
+    expect(result.current.templates[1].id).toBe(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('handles fetch error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const { result } = renderHook(() => useTemplates());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Network error');
+    expect(result.current.templates).toEqual([]);
+  });
+
+  it('creates new template and adds to top of list', async () => {
+    const newTemplate: AdTemplate = {
+      id: 3,
+      name: 'New Template',
+      html: '<div>New</div>',
+      placeholders: ['title'],
+      description: 'New Description',
+      created_at: '2024-01-03T00:00:00Z',
+      updated_at: '2024-01-03T00:00:00Z',
+    };
+
+    // Initial fetch
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockTemplates),
+    } as Response);
+
+    const { result } = renderHook(() => useTemplates());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.templates).toHaveLength(2);
+
+    // Create template
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(newTemplate),
+    } as Response);
+
+    const formData: CreateAdTemplateRequest = {
+      name: 'New Template',
+      html: '<div>New</div>',
+      placeholders: ['title'],
+      description: 'New Description',
+    };
+
+    await result.current.createTemplate(formData, false);
+
+    await waitFor(() => {
+      expect(result.current.templates).toHaveLength(3);
+    });
+    expect(result.current.templates[0]).toEqual(newTemplate);
+  });
+
+  it('calls updateTemplate API with correct parameters', async () => {
+    // Initial fetch
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockTemplates),
+    } as Response);
+
+    const { result } = renderHook(() => useTemplates());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Update template
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockTemplates[1]),
+    } as Response);
+
+    const formData: CreateAdTemplateRequest = {
+      name: 'Updated Template',
+      html: '<div>Updated</div>',
+      placeholders: ['title'],
+      description: 'Updated Description',
+    };
+
+    await result.current.updateTemplate(2, formData, false);
+
+    expect(mockFetch).toHaveBeenLastCalledWith('/api/templates/2', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(formData),
+    });
+  });
+
+  it('deletes template and removes from list', async () => {
+    // Mock window.confirm
+    Object.defineProperty(window, 'confirm', {
+      writable: true,
+      value: jest.fn(() => true),
+    });
+
+    // Initial fetch
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockTemplates),
+    } as Response);
+
+    const { result } = renderHook(() => useTemplates());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Delete template
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    } as Response);
+
+    await result.current.deleteTemplate(1);
+
+    await waitFor(() => {
+      expect(result.current.templates).toHaveLength(1);
+    });
+    expect(result.current.templates[0].id).toBe(2);
+  });
+
+  it('cancels delete when user clicks cancel', async () => {
+    // Mock window.confirm to return false
+    Object.defineProperty(window, 'confirm', {
+      writable: true,
+      value: jest.fn(() => false),
+    });
+
+    // Initial fetch
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockTemplates),
+    } as Response);
+
+    const { result } = renderHook(() => useTemplates());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await result.current.deleteTemplate(1);
+
+    // Templates should remain unchanged
+    expect(result.current.templates).toHaveLength(2);
+    expect(mockFetch).toHaveBeenCalledTimes(1); // Only initial fetch
+  });
+
+  it('handles templates without updated_at during sorting', async () => {
+    const templatesWithoutDates = [
+      { ...mockTemplates[0], updated_at: undefined },
+      { ...mockTemplates[1], updated_at: undefined },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(templatesWithoutDates),
+    } as Response);
+
+    const { result } = renderHook(() => useTemplates());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.templates).toHaveLength(2);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('applies nofollow when autoNofollow is true', async () => {
+    const newTemplate: AdTemplate = {
+      id: 3,
+      name: 'New Template',
+      html: '<div>New</div> with nofollow',
+      placeholders: ['title'],
+      description: 'New Description',
+      created_at: '2024-01-03T00:00:00Z',
+      updated_at: '2024-01-03T00:00:00Z',
+    };
+
+    // Initial fetch
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve([]),
+    } as Response);
+
+    const { result } = renderHook(() => useTemplates());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Create template with autoNofollow
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(newTemplate),
+    } as Response);
+
+    const formData: CreateAdTemplateRequest = {
+      name: 'New Template',
+      html: '<div>New</div>',
+      placeholders: ['title'],
+      description: 'New Description',
+    };
+
+    await result.current.createTemplate(formData, true);
+
+    expect(mockFetch).toHaveBeenLastCalledWith('/api/templates', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...formData,
+        html: '<div>New</div> with nofollow',
+      }),
+    });
+  });
+});

--- a/public/images/sample-ad.svg
+++ b/public/images/sample-ad.svg
@@ -1,0 +1,9 @@
+<svg width="300" height="200" xmlns="http://www.w3.org/2000/svg">
+  <rect width="300" height="200" fill="#f3f4f6"/>
+  <rect x="20" y="20" width="260" height="160" fill="#ffffff" stroke="#e5e7eb" stroke-width="2"/>
+  <text x="150" y="80" text-anchor="middle" font-family="Arial, sans-serif" font-size="16" fill="#374151">サンプル広告画像</text>
+  <text x="150" y="110" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#6b7280">300 × 200</text>
+  <circle cx="80" cy="140" r="15" fill="#3b82f6"/>
+  <circle cx="150" cy="140" r="15" fill="#10b981"/>
+  <circle cx="220" cy="140" r="15" fill="#f59e0b"/>
+</svg>

--- a/src/app/accounts/components/UserForm.tsx
+++ b/src/app/accounts/components/UserForm.tsx
@@ -50,10 +50,11 @@ export default function UserForm({ user, onClose, onSuccess }: UserFormProps) {
           {isEdit && <input type="hidden" name="id" value={user.id} />}
           
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-1">
               名前
             </label>
             <input
+              id="name"
               type="text"
               name="name"
               value={formValues.name}
@@ -64,10 +65,11 @@ export default function UserForm({ user, onClose, onSuccess }: UserFormProps) {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
               メールアドレス
             </label>
             <input
+              id="email"
               type="email"
               name="email"
               value={formValues.email}
@@ -80,10 +82,11 @@ export default function UserForm({ user, onClose, onSuccess }: UserFormProps) {
           <input type="hidden" name="role" value="editor" />
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
               パスワード {isEdit && '(変更する場合のみ)'}
             </label>
             <input
+              id="password"
               type="password"
               name="password"
               value={formValues.password}

--- a/src/app/ad-templates/components/ImportExportButtons.tsx
+++ b/src/app/ad-templates/components/ImportExportButtons.tsx
@@ -68,7 +68,7 @@ export default function ImportExportButtons({
             <div className="bg-white p-3 rounded border text-xs font-mono overflow-x-auto">
               <div>name,html,placeholders,description</div>
               <div
-                className="text-gray-600">&quot;サンプル広告&quot;,&quot;&lt;div&gt;&#123;&#123;title&#125;&#125;&lt;/div&gt;&quot;,&quot;title,linkUrl&quot;,&quot;サンプルの説明&quot;</div>
+                className="text-gray-600">&quot;サンプル広告&quot;,&quot;&lt;a href=&#123;&#123;linkUrl&#125;&#125;&gt;&lt;div&gt;&#123;&#123;title&#125;&#125;&lt;/div&gt;&lt;/a&gt;&quot;,&quot;title,linkUrl&quot;,&quot;サンプルの説明&quot;</div>
             </div>
             <div className="mt-3 text-xs text-blue-600">
               <strong>注意:</strong> placeholders列には、プレースホルダーをカンマで区切って記載してください

--- a/src/app/ad-templates/components/ImportExportButtons.tsx
+++ b/src/app/ad-templates/components/ImportExportButtons.tsx
@@ -77,14 +77,16 @@ export default function ImportExportButtons({
 
           <form onSubmit={handleImport} className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label htmlFor="csv-file" className="block text-sm font-medium text-gray-700 mb-2">
                 CSVファイルを選択
               </label>
               <input
+                id="csv-file"
                 type="file"
                 name="file"
                 accept=".csv"
                 required
+                disabled={importLoading}
                 className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100 file:cursor-pointer"
               />
             </div>
@@ -100,7 +102,8 @@ export default function ImportExportButtons({
               <button
                 type="button"
                 onClick={onImportCancel}
-                className="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-lg transition-colors cursor-pointer"
+                disabled={importLoading}
+                className="bg-gray-600 hover:bg-gray-700 disabled:bg-gray-400 text-white px-4 py-2 rounded-lg transition-colors cursor-pointer"
               >
                 キャンセル
               </button>

--- a/src/app/ad-templates/components/TemplateForm.tsx
+++ b/src/app/ad-templates/components/TemplateForm.tsx
@@ -136,7 +136,7 @@ export default function TemplateForm({
           />
           <div className="flex justify-between items-start mt-1">
             <p className="text-xs text-gray-500">
-              例: &lt;div class=&quot;ad-banner&quot;&gt;&lt;h2&gt;&#123;&#123;title&#125;&#125;&lt;/h2&gt;&lt;img src=&quot;&#123;&#123;imageUrl&#125;&#125;&quot; /&gt;&lt;/div&gt;
+              例: &lt;div class=&quot;ad-banner&quot;&gt;&lt;h2&gt;&#123;&#123;title&#125;&#125;&lt;/h2&gt;&lt;a href=&quot;&#123;&#123;linkUrl&#125;&#125;&quot;&gt;&lt;img src=&quot;&#123;&#123;imageUrl&#125;&#125;&quot; /&gt;&lt;/a&gt;&lt;/div&gt;
             </p>
             {autoNofollow && (
               <p className="text-xs text-blue-600 bg-blue-50 px-2 py-1 rounded">
@@ -200,7 +200,7 @@ export default function TemplateForm({
                       type="text"
                       value={placeholder}
                       onChange={(e) => updatePlaceholder(index, e.target.value)}
-                      placeholder="プレースホルダー名（例：title, imageUrl）"
+                      placeholder="プレースホルダー名（例：title, imageUrl, linkUrl）"
                       className={`w-full px-3 py-2 border rounded-md focus:ring-blue-500 focus:border-blue-500 ${
                         placeholder.trim() && !isValid
                           ? 'border-red-300 bg-red-50'

--- a/src/app/ad-templates/components/TemplatePreview.tsx
+++ b/src/app/ad-templates/components/TemplatePreview.tsx
@@ -139,10 +139,11 @@ export default function TemplatePreview({
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               {formData.placeholders.map((placeholder: string) => (
                 <div key={placeholder} className="space-y-1">
-                  <label className="text-sm font-medium text-gray-700">
+                  <label htmlFor={`custom-${placeholder}`} className="text-sm font-medium text-gray-700">
                     {placeholder}
                   </label>
                   <input
+                    id={`custom-${placeholder}`}
                     type="text"
                     value={customValues[placeholder] || ''}
                     onChange={(e) => updateCustomValue(placeholder, e.target.value)}

--- a/src/app/ad-templates/components/TemplatePreview.tsx
+++ b/src/app/ad-templates/components/TemplatePreview.tsx
@@ -7,9 +7,9 @@ interface TemplatePreviewProps {
   formData: CreateAdTemplateRequest;
   previewMode: 'sample' | 'custom';
   customValues: Record<string, string>;
-  previewSize: 'desktop' | 'tablet' | 'mobile';
+  previewSize: 'desktop' | 'mobile';
   setPreviewMode: (mode: 'sample' | 'custom') => void;
-  setPreviewSize: (size: 'desktop' | 'tablet' | 'mobile') => void;
+  setPreviewSize: (size: 'desktop' | 'mobile') => void;
   updateCustomValue: (placeholder: string, value: string) => void;
 }
 
@@ -48,7 +48,6 @@ export default function TemplatePreview({
 
     const sizeClasses = {
       desktop: 'max-w-full',
-      tablet: 'max-w-md mx-auto',
       mobile: 'max-w-xs mx-auto'
     };
 
@@ -118,17 +117,6 @@ export default function TemplatePreview({
                 }`}
               >
                 🖥️
-              </button>
-              <button
-                type="button"
-                onClick={() => setPreviewSize('tablet')}
-                className={`px-3 py-1 transition-colors ${
-                  previewSize === 'tablet' 
-                    ? 'bg-green-600 text-white' 
-                    : 'bg-gray-100 hover:bg-gray-200 text-gray-700'
-                }`}
-              >
-                📱
               </button>
               <button
                 type="button"

--- a/src/app/ad-templates/page.tsx
+++ b/src/app/ad-templates/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import ClientProtectedPage from '@/components/ClientProtectedPage';
 import {useState, useEffect, useCallback, useRef} from 'react';
 import type {AdTemplate, CreateAdTemplateRequest} from '@/lib/definitions';
 import {extractPlaceholders, validatePlaceholders} from '@/lib/template-utils';
@@ -262,73 +263,75 @@ export default function AdTemplates() {
   }
 
   return (
-    <div>
-      <div className="space-y-6">
-        {error && (
-          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
-            {error}
-            <button
-              onClick={() => setError(null)}
-              className="float-right text-red-500 hover:text-red-700 cursor-pointer"
-            >
-              ×
-            </button>
-          </div>
-        )}
+    <ClientProtectedPage>
+      <div>
+        <div className="space-y-6">
+          {error && (
+            <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+              {error}
+              <button
+                onClick={() => setError(null)}
+                className="float-right text-red-500 hover:text-red-700 cursor-pointer"
+              >
+                ×
+              </button>
+            </div>
+          )}
 
-        <ImportExportButtons
-          onImport={handleImportClick}
-          onExport={handleExport}
-          onCreateClick={handleCreateClick}
-          onImportCancel={handleImportCancel}
-          exportLoading={exportLoading}
-          showImportForm={showImportForm}
-          importLoading={importLoading}
-          importResult={importResult}
-          handleImport={handleImport}
-        />
+          <ImportExportButtons
+            onImport={handleImportClick}
+            onExport={handleExport}
+            onCreateClick={handleCreateClick}
+            onImportCancel={handleImportCancel}
+            exportLoading={exportLoading}
+            showImportForm={showImportForm}
+            importLoading={importLoading}
+            importResult={importResult}
+            handleImport={handleImport}
+          />
 
-        {showCreateForm && (
-          <div ref={formRef} className="bg-white rounded-lg shadow p-6">
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <div className="space-y-4">
-                <TemplateForm
-                  formData={formData}
-                  setFormData={setFormData}
-                  validationErrors={validationErrors}
-                  autoNofollow={autoNofollow}
-                  setAutoNofollow={setAutoNofollow}
-                  showNamingGuide={showNamingGuide}
-                  setShowNamingGuide={setShowNamingGuide}
-                  editingTemplate={editingTemplate}
-                  onSubmit={handleSubmit}
-                  onCancel={handleCancel}
-                  autoExtractPlaceholders={autoExtractPlaceholders}
-                />
-              </div>
+          {showCreateForm && (
+            <div ref={formRef} className="bg-white rounded-lg shadow p-6">
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <div className="space-y-4">
+                  <TemplateForm
+                    formData={formData}
+                    setFormData={setFormData}
+                    validationErrors={validationErrors}
+                    autoNofollow={autoNofollow}
+                    setAutoNofollow={setAutoNofollow}
+                    showNamingGuide={showNamingGuide}
+                    setShowNamingGuide={setShowNamingGuide}
+                    editingTemplate={editingTemplate}
+                    onSubmit={handleSubmit}
+                    onCancel={handleCancel}
+                    autoExtractPlaceholders={autoExtractPlaceholders}
+                  />
+                </div>
 
-              <div className="space-y-4">
-                <TemplatePreview
-                  formData={formData}
-                  previewMode={previewMode}
-                  customValues={customValues}
-                  previewSize={previewSize}
-                  setPreviewMode={setPreviewMode}
-                  setPreviewSize={setPreviewSize}
-                  updateCustomValue={updateCustomValue}
-                />
+                <div className="space-y-4">
+                  <TemplatePreview
+                    formData={formData}
+                    previewMode={previewMode}
+                    customValues={customValues}
+                    previewSize={previewSize}
+                    setPreviewMode={setPreviewMode}
+                    setPreviewSize={setPreviewSize}
+                    updateCustomValue={updateCustomValue}
+                  />
+                </div>
               </div>
             </div>
-          </div>
-        )}
+          )}
 
-        <TemplateList
-          templates={templates}
-          onEdit={handleEdit}
-          onDelete={handleDelete}
-          onCreateClick={handleCreateClick}
-        />
+          <TemplateList
+            templates={templates}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+            onCreateClick={handleCreateClick}
+          />
+        </div>
       </div>
-    </div>
+    </ClientProtectedPage>
   );
 }

--- a/src/app/ad-templates/page.tsx
+++ b/src/app/ad-templates/page.tsx
@@ -38,7 +38,7 @@ export default function AdTemplates() {
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
   const [previewMode, setPreviewMode] = useState<'sample' | 'custom'>('sample');
   const [customValues, setCustomValues] = useState<Record<string, string>>({});
-  const [previewSize, setPreviewSize] = useState<'desktop' | 'tablet' | 'mobile'>('desktop');
+  const [previewSize, setPreviewSize] = useState<'desktop' | 'mobile'>('desktop');
   const [autoNofollow, setAutoNofollow] = useState(true);
   const formRef = useRef<HTMLDivElement>(null);
 

--- a/src/app/ads/page.tsx
+++ b/src/app/ads/page.tsx
@@ -1,80 +1,83 @@
+import ProtectedPage from '@/components/ProtectedPage';
 
 export default function Ads() {
   return (
-    <div>
-      <div className="space-y-6">
-        <div className="flex justify-between items-center">
-          <h1 className="text-3xl font-bold text-gray-900">広告管理</h1>
-          <button
-            className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg transition-colors cursor-pointer">
-            新しい広告を作成
-          </button>
-        </div>
-
-        <div className="bg-white rounded-lg shadow">
-          <div className="p-6 border-b border-gray-200">
-            <div className="flex gap-4">
-              <input
-                type="text"
-                placeholder="広告名で検索..."
-                className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
-              <select
-                className="px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
-                <option value="">すべてのステータス</option>
-                <option value="active">アクティブ</option>
-                <option value="paused">停止中</option>
-                <option value="draft">下書き</option>
-              </select>
-              <button className="px-4 py-2 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors cursor-pointer">
-                検索
-              </button>
-            </div>
+    <ProtectedPage>
+      <div>
+        <div className="space-y-6">
+          <div className="flex justify-between items-center">
+            <h1 className="text-3xl font-bold text-gray-900">広告管理</h1>
+            <button
+              className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg transition-colors cursor-pointer">
+              新しい広告を作成
+            </button>
           </div>
 
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead className="bg-gray-50">
-              <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  広告名
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  テンプレート
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  ステータス
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  作成日
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  最終更新
-                </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  操作
-                </th>
-              </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
-              <tr>
-                <td colSpan={6} className="px-6 py-12 text-center text-gray-500">
-                  <div className="flex flex-col items-center">
-                    <div className="text-4xl mb-4">📋</div>
-                    <h3 className="text-lg font-medium mb-2">広告がありません</h3>
-                    <p className="text-gray-400 mb-4">最初の広告を作成してみましょう</p>
-                    <button
-                      className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded transition-colors cursor-pointer">
-                      最初の広告を作成
-                    </button>
-                  </div>
-                </td>
-              </tr>
-              </tbody>
-            </table>
+          <div className="bg-white rounded-lg shadow">
+            <div className="p-6 border-b border-gray-200">
+              <div className="flex gap-4">
+                <input
+                  type="text"
+                  placeholder="広告名で検索..."
+                  className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+                <select
+                  className="px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+                  <option value="">すべてのステータス</option>
+                  <option value="active">アクティブ</option>
+                  <option value="paused">停止中</option>
+                  <option value="draft">下書き</option>
+                </select>
+                <button className="px-4 py-2 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors cursor-pointer">
+                  検索
+                </button>
+              </div>
+            </div>
+
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    広告名
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    テンプレート
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    ステータス
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    作成日
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    最終更新
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    操作
+                  </th>
+                </tr>
+                </thead>
+                <tbody className="bg-white divide-y divide-gray-200">
+                <tr>
+                  <td colSpan={6} className="px-6 py-12 text-center text-gray-500">
+                    <div className="flex flex-col items-center">
+                      <div className="text-4xl mb-4">📋</div>
+                      <h3 className="text-lg font-medium mb-2">広告がありません</h3>
+                      <p className="text-gray-400 mb-4">最初の広告を作成してみましょう</p>
+                      <button
+                        className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded transition-colors cursor-pointer">
+                        最初の広告を作成
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </ProtectedPage>
   );
 }

--- a/src/app/article-ad-mapping/page.tsx
+++ b/src/app/article-ad-mapping/page.tsx
@@ -1,30 +1,33 @@
+import ProtectedPage from '@/components/ProtectedPage';
 
 export default function ArticleAdMapping() {
   return (
-    <div>
-      <div className="space-y-6">
-        <div className="flex justify-between items-center">
-          <h1 className="text-3xl font-bold text-gray-900">記事と広告の紐付け管理</h1>
-          <button
-            className="bg-purple-600 hover:bg-purple-700 text-white px-6 py-2 rounded-lg transition-colors cursor-pointer">
-            新しい紐付けを作成
-          </button>
-        </div>
+    <ProtectedPage>
+      <div>
+        <div className="space-y-6">
+          <div className="flex justify-between items-center">
+            <h1 className="text-3xl font-bold text-gray-900">記事と広告の紐付け管理</h1>
+            <button
+              className="bg-purple-600 hover:bg-purple-700 text-white px-6 py-2 rounded-lg transition-colors cursor-pointer">
+              新しい紐付けを作成
+            </button>
+          </div>
 
-        <div className="bg-white rounded-lg shadow">
-          <div className="p-6">
-            <div className="text-center py-12 text-gray-500">
-              <div className="text-4xl mb-4">🔗</div>
-              <h3 className="text-lg font-medium mb-2">紐付けがありません</h3>
-              <p className="text-gray-400">記事と広告の紐付け関係がここに表示されます</p>
-              <button
-                className="mt-4 bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded transition-colors cursor-pointer">
-                最初の紐付けを作成
-              </button>
+          <div className="bg-white rounded-lg shadow">
+            <div className="p-6">
+              <div className="text-center py-12 text-gray-500">
+                <div className="text-4xl mb-4">🔗</div>
+                <h3 className="text-lg font-medium mb-2">紐付けがありません</h3>
+                <p className="text-gray-400">記事と広告の紐付け関係がここに表示されます</p>
+                <button
+                  className="mt-4 bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded transition-colors cursor-pointer">
+                  最初の紐付けを作成
+                </button>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </ProtectedPage>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
-
 'use client';
 
+import ClientProtectedPage from '@/components/ClientProtectedPage';
 import {useState, useEffect} from 'react';
 import type {AdTemplate} from '@/lib/definitions';
 
@@ -36,11 +36,11 @@ export default function Dashboard() {
   const fetchDashboardData = async () => {
     try {
       setLoading(true);
-      
+
       // 広告テンプレート数を取得
       const templatesResponse = await fetch('/api/templates');
       const templates = templatesResponse.ok ? await templatesResponse.json() : [];
-      
+
       setStats({
         totalAds: 0, // 今後実装予定
         adTemplates: templates.length,
@@ -87,56 +87,59 @@ export default function Dashboard() {
   }
 
   return (
-    <div>
-      <div className="space-y-6">
-        <h1 className="text-3xl font-bold text-gray-900">ダッシュボード</h1>
+    <ClientProtectedPage>
+      <div>
+        <div className="space-y-6">
+          <h1 className="text-3xl font-bold text-gray-900">ダッシュボード</h1>
 
-        {error && (
-          <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
-            {error}
+          {error && (
+            <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+              {error}
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+            <div className="bg-white p-6 rounded-lg shadow">
+              <h3 className="text-lg font-semibold text-gray-700 mb-2">総広告数</h3>
+              <p className="text-3xl font-bold text-blue-600">{stats.totalAds}</p>
+            </div>
+
+            <div className="bg-white p-6 rounded-lg shadow">
+              <h3 className="text-lg font-semibold text-gray-700 mb-2">広告テンプレート数</h3>
+              <p className="text-3xl font-bold text-green-600">{stats.adTemplates}</p>
+            </div>
+
+            <div className="bg-white p-6 rounded-lg shadow">
+              <h3 className="text-lg font-semibold text-gray-700 mb-2">URLテンプレート数</h3>
+              <p className="text-3xl font-bold text-purple-600">{stats.urlTemplates}</p>
+            </div>
+
+            <div className="bg-white p-6 rounded-lg shadow">
+              <h3 className="text-lg font-semibold text-gray-700 mb-2">広告なし記事数</h3>
+              <p className="text-3xl font-bold text-orange-600">{stats.articlesWithoutAds}</p>
+            </div>
           </div>
-        )}
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           <div className="bg-white p-6 rounded-lg shadow">
-            <h3 className="text-lg font-semibold text-gray-700 mb-2">総広告数</h3>
-            <p className="text-3xl font-bold text-blue-600">{stats.totalAds}</p>
-          </div>
-
-          <div className="bg-white p-6 rounded-lg shadow">
-            <h3 className="text-lg font-semibold text-gray-700 mb-2">広告テンプレート数</h3>
-            <p className="text-3xl font-bold text-green-600">{stats.adTemplates}</p>
-          </div>
-
-          <div className="bg-white p-6 rounded-lg shadow">
-            <h3 className="text-lg font-semibold text-gray-700 mb-2">URLテンプレート数</h3>
-            <p className="text-3xl font-bold text-purple-600">{stats.urlTemplates}</p>
-          </div>
-
-          <div className="bg-white p-6 rounded-lg shadow">
-            <h3 className="text-lg font-semibold text-gray-700 mb-2">広告なし記事数</h3>
-            <p className="text-3xl font-bold text-orange-600">{stats.articlesWithoutAds}</p>
-          </div>
-        </div>
-
-        <div className="bg-white p-6 rounded-lg shadow">
-          <h2 className="text-xl font-semibold text-gray-900 mb-4">最近の活動</h2>
-          <div className="space-y-3">
-            {activities.length > 0 ? (
-              activities.map((activity) => (
-                <div key={activity.id} className="flex items-center justify-between py-2 border-b border-gray-200 last:border-b-0">
-                  <span className="text-gray-600">{activity.message}</span>
-                  <span className="text-sm text-gray-500">{activity.date}</span>
+            <h2 className="text-xl font-semibold text-gray-900 mb-4">最近の活動</h2>
+            <div className="space-y-3">
+              {activities.length > 0 ? (
+                activities.map((activity) => (
+                  <div key={activity.id}
+                       className="flex items-center justify-between py-2 border-b border-gray-200 last:border-b-0">
+                    <span className="text-gray-600">{activity.message}</span>
+                    <span className="text-sm text-gray-500">{activity.date}</span>
+                  </div>
+                ))
+              ) : (
+                <div className="text-center py-8 text-gray-400">
+                  <p>活動履歴がここに表示されます</p>
                 </div>
-              ))
-            ) : (
-              <div className="text-center py-8 text-gray-400">
-                <p>活動履歴がここに表示されます</p>
-              </div>
-            )}
+              )}
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </ClientProtectedPage>
   );
 }

--- a/src/app/url-templates/page.tsx
+++ b/src/app/url-templates/page.tsx
@@ -1,30 +1,33 @@
+import ProtectedPage from '@/components/ProtectedPage';
 
 export default function UrlTemplates() {
   return (
-    <div>
-      <div className="space-y-6">
-        <div className="flex justify-between items-center">
-          <h1 className="text-3xl font-bold text-gray-900">URLテンプレート管理</h1>
-          <button
-            className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg transition-colors cursor-pointer">
-            新しいテンプレートを作成
-          </button>
-        </div>
+    <ProtectedPage>
+      <div>
+        <div className="space-y-6">
+          <div className="flex justify-between items-center">
+            <h1 className="text-3xl font-bold text-gray-900">URLテンプレート管理</h1>
+            <button
+              className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg transition-colors cursor-pointer">
+              新しいテンプレートを作成
+            </button>
+          </div>
 
-        <div className="bg-white rounded-lg shadow">
-          <div className="p-6">
-            <div className="text-center py-12 text-gray-500">
-              <div className="text-4xl mb-4">🔗</div>
-              <h3 className="text-lg font-medium mb-2">URLテンプレートがありません</h3>
-              <p className="text-gray-400">計測パラメータ付きのURLテンプレートを作成して始めましょう</p>
-              <button
-                className="mt-4 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded transition-colors cursor-pointer">
-                最初のテンプレートを作成
-              </button>
+          <div className="bg-white rounded-lg shadow">
+            <div className="p-6">
+              <div className="text-center py-12 text-gray-500">
+                <div className="text-4xl mb-4">🔗</div>
+                <h3 className="text-lg font-medium mb-2">URLテンプレートがありません</h3>
+                <p className="text-gray-400">計測パラメータ付きのURLテンプレートを作成して始めましょう</p>
+                <button
+                  className="mt-4 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded transition-colors cursor-pointer">
+                  最初のテンプレートを作成
+                </button>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </ProtectedPage>
   );
 }

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -13,7 +13,7 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
   if (status === 'loading') {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+        <div data-testid="loading-spinner" className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
       </div>
     );
   }

--- a/src/components/ClientProtectedPage.tsx
+++ b/src/components/ClientProtectedPage.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import {useSession} from 'next-auth/react';
+import {useRouter} from 'next/navigation';
+import {useEffect} from 'react';
+
+interface ClientProtectedPageProps {
+  children: React.ReactNode;
+}
+
+export default function ClientProtectedPage({children}: ClientProtectedPageProps) {
+  const {data: session, status} = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === 'loading') return; // Still loading
+
+    if (!session?.user) {
+      router.push('/login');
+      return;
+    }
+  }, [session, status, router]);
+
+  if (status === 'loading') {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  if (!session?.user) {
+    return null; // Will redirect
+  }
+
+  return <>{children}</>;
+}

--- a/src/lib/template-utils/placeholder-extraction.ts
+++ b/src/lib/template-utils/placeholder-extraction.ts
@@ -19,7 +19,7 @@ export function getSampleValue(placeholder: string): string {
   // 画像関連のプレースホルダー
   if (lowerPlaceholder.includes('image') || lowerPlaceholder.includes('img') || lowerPlaceholder.includes('picture') ||
     lowerPlaceholder.includes('photo') || lowerPlaceholder.includes('banner')) {
-    return 'https://picsum.photos/300/200';
+    return '/images/sample-ad.svg';
   }
 
   // URL関連のプレースホルダー


### PR DESCRIPTION
<!-- for GitHub Copilot review rule
  - Review comments should be written in Japanese.
  - Add the following prefixes to your review comments.
    [MUST] → should be fixed
    [IMO] → in my opinion
    [NITS] → nitpick
    [ASK] → question
-->

## 関連Issue

<!-- 関連するIssueがあれば記載してください -->
Closes #37

## 概要

<!-- このPRで何を変更したかを簡潔に説明してください -->
広告テンプレート管理機能における複数の修正と改善を実装しました。テンプレートの順序表示、画像リソースの最適化、包括的なテストスイートの追加、アクセシビリティの向上を行いました。

## 変更内容

<!-- 具体的な変更点をリストアップしてください -->

- [x] テンプレート一覧の順序を編集日時順に変更（編集されたテンプレートが上位表示）
- [x] 外部画像リソースを静的アセットに置き換え
- [x] 包括的なテストスイートの追加とコンポーネントアクセシビリティの改善
- [x] linkUrlをテンプレート編集例に追加
- [x] README.mdを最新のプロジェクト状態に基づいて更新

## 変更理由

<!-- なぜこの変更が必要だったかを説明してください -->
Issue #37で報告された広告テンプレート管理機能の改善要求に対応するため。ユーザビリティの向上、パフォーマンスの最適化、コード品質の向上を目的としています。

## 動作確認

<!-- テストした項目にチェックを入れてください -->

- [x] テンプレート一覧の順序が正しく表示されること
- [x] 静的画像が正常に読み込まれること  
- [x] 全テストが正常に実行されること
- [x] アクセシビリティ機能が適切に動作すること

## スクリーンショット

<!-- UIに変更がある場合は、変更前後のスクリーンショットを添付してください -->

### Before

<!-- 変更前 -->
外部画像リソースを使用し、テンプレート順序が作成日時順でした。

### After

<!-- 変更後 -->
静的アセットを使用し、編集されたテンプレートが上位に表示されます。

## 補足事項

<!-- その他、レビュアーに伝えたいことがあれば記載してください -->
この変更により、テンプレート管理のユーザビリティが大幅に向上し、パフォーマンスも改善されます。テストカバレッジも大幅に向上し、今後の機能追加や修正がより安全に行えるようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- for GitHub Copilot review rule
  - Review comments should be written in Japanese.
  - Add the following prefixes to your review comments.
    [MUST] → should be fixed
    [IMO] → in my opinion
    [NITS] → nitpick
    [ASK] → question
-->