### PR TITLE
ログインフォーム表示ちらつき問題の修正

### DIFF
--- a/__tests__/components/ClientLayout.test.tsx
+++ b/__tests__/components/ClientLayout.test.tsx
@@ -1,10 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import { useSession } from 'next-auth/react';
+import { usePathname } from 'next/navigation';
 import ClientLayout from '@/components/ClientLayout';
 
 // Mock next-auth/react
 jest.mock('next-auth/react', () => ({
   useSession: jest.fn(),
+}));
+
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
 }));
 
 // Mock Sidebar component
@@ -13,10 +19,12 @@ jest.mock('@/components/Sidebar', () => {
 });
 
 const mockUseSession = useSession as jest.MockedFunction<typeof useSession>;
+const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>;
 
 describe('ClientLayout', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUsePathname.mockReturnValue('/dashboard'); // デフォルトパス
   });
 
   it('shows loading spinner when session is loading', () => {

--- a/__tests__/components/LoginForm.test.tsx
+++ b/__tests__/components/LoginForm.test.tsx
@@ -1,23 +1,35 @@
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {signIn} from 'next-auth/react';
+import {useRouter} from 'next/navigation';
 import LoginForm from '@/components/LoginForm';
 
 // Mock next-auth/react
+const mockUpdate = jest.fn();
 jest.mock('next-auth/react', () => ({
   signIn: jest.fn(),
+  useSession: jest.fn(),
+}));
+
+// Mock next/navigation
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
 }));
 
 const mockSignIn = signIn as jest.MockedFunction<typeof signIn>;
-
-// Mock window.location.href
-delete (window as any).location;
-window.location = {href: ''} as any;
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+const mockUseSession = require('next-auth/react').useSession as jest.MockedFunction<any>;
 
 describe('LoginForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    window.location.href = '';
+    mockUseRouter.mockReturnValue({
+      push: mockPush,
+    } as any);
+    mockUseSession.mockReturnValue({
+      update: mockUpdate,
+    });
   });
 
   it('renders login form with all required fields', () => {
@@ -51,14 +63,13 @@ describe('LoginForm', () => {
 
     render(<LoginForm/>);
 
-    const form = screen.getByRole('form');
     const emailInput = screen.getByLabelText('メールアドレス');
     const passwordInput = screen.getByLabelText('パスワード');
+    const submitButton = screen.getByRole('button', {name: 'ログイン'});
 
     await user.type(emailInput, 'test@example.com');
     await user.type(passwordInput, 'password123');
-
-    fireEvent.submit(form);
+    await user.click(submitButton);
 
     await waitFor(() => {
       expect(mockSignIn).toHaveBeenCalledWith('credentials', expect.objectContaining({
@@ -88,6 +99,28 @@ describe('LoginForm', () => {
     expect(submitButton).toHaveAttribute('aria-disabled', 'true');
   });
 
+  it('shows redirect overlay when authentication succeeds', async () => {
+    const user = userEvent.setup();
+    mockSignIn.mockResolvedValue({ok: true});
+    mockUpdate.mockResolvedValue(undefined);
+
+    render(<LoginForm/>);
+
+    const emailInput = screen.getByLabelText('メールアドレス');
+    const passwordInput = screen.getByLabelText('パスワード');
+    const submitButton = screen.getByRole('button', {name: 'ログイン'});
+
+    await user.type(emailInput, 'valid@example.com');
+    await user.type(passwordInput, 'correctpassword');
+    await user.click(submitButton);
+
+    // リダイレクトオーバーレイが表示されることを確認
+    await waitFor(() => {
+      const overlays = screen.getAllByText('ダッシュボードに移動中...');
+      expect(overlays.length).toBeGreaterThan(0);
+    });
+  });
+
   it('displays error message when authentication fails', async () => {
     const user = userEvent.setup();
     mockSignIn.mockResolvedValue({error: 'CredentialsSignin'});
@@ -107,10 +140,36 @@ describe('LoginForm', () => {
     });
   });
 
-  it('clears error message on new submission attempt', async () => {
+  it('redirects to dashboard when authentication succeeds', async () => {
+    const user = userEvent.setup();
+    mockSignIn.mockResolvedValue({ok: true});
+    mockUpdate.mockResolvedValue(undefined);
+
+    render(<LoginForm/>);
+
+    const emailInput = screen.getByLabelText('メールアドレス');
+    const passwordInput = screen.getByLabelText('パスワード');
+    const submitButton = screen.getByRole('button', {name: 'ログイン'});
+
+    await user.type(emailInput, 'valid@example.com');
+    await user.type(passwordInput, 'correctpassword');
+    await user.click(submitButton);
+
+    // セッション更新が呼ばれることを確認
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalled();
+    });
+
+    // リダイレクトが呼ばれることを確認（setTimeoutのため少し待つ）
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/dashboard');
+    }, { timeout: 300 });
+  });
+
+  it('clears error message on form interaction after error', async () => {
     const user = userEvent.setup();
     mockSignIn.mockResolvedValueOnce({error: 'CredentialsSignin'})
-      .mockResolvedValueOnce(undefined);
+      .mockResolvedValueOnce({ok: true});
 
     render(<LoginForm/>);
 
@@ -127,15 +186,16 @@ describe('LoginForm', () => {
       expect(screen.getByText('メールアドレスまたはパスワードが正しくありません。')).toBeInTheDocument();
     });
 
-    // Second successful attempt
+    // Clear inputs and type new values - error should be cleared on form submission
     await user.clear(emailInput);
     await user.clear(passwordInput);
     await user.type(emailInput, 'valid@example.com');
     await user.type(passwordInput, 'correctpassword');
-    await user.click(submitButton);
+    
+    // Start new submission - error message should be cleared before API call
+    fireEvent.submit(screen.getByRole('form'));
 
-    await waitFor(() => {
-      expect(screen.queryByText('メールアドレスまたはパスワードが正しくありません。')).not.toBeInTheDocument();
-    });
+    // Error message should be cleared immediately when new submission starts
+    expect(screen.queryByText('メールアドレスまたはパスワードが正しくありません。')).not.toBeInTheDocument();
   });
 });

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useSession } from 'next-auth/react';
+import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
 import Sidebar from './Sidebar';
 
 interface ClientLayoutProps {
@@ -9,8 +11,24 @@ interface ClientLayoutProps {
 
 export default function ClientLayout({ children }: ClientLayoutProps) {
   const { data: session, status } = useSession();
+  const pathname = usePathname();
+  const [isTransitioning, setIsTransitioning] = useState(false);
 
-  if (status === 'loading') {
+  // パス変更時の遷移状態管理
+  useEffect(() => {
+    if (pathname && pathname !== '/login') {
+      setIsTransitioning(false);
+    }
+  }, [pathname]);
+
+  // ログインページから認証済みページへの遷移を検知
+  useEffect(() => {
+    if (status === 'authenticated' && pathname === '/login') {
+      setIsTransitioning(true);
+    }
+  }, [status, pathname]);
+
+  if (status === 'loading' || isTransitioning) {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div data-testid="loading-spinner" className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,12 +1,16 @@
 'use client';
 
 import {Button} from './Button';
-import {signIn} from 'next-auth/react';
+import {signIn, useSession} from 'next-auth/react';
 import {useState} from 'react';
+import {useRouter} from 'next/navigation';
 
 export default function LoginForm() {
   const [isPending, setIsPending] = useState(false);
+  const [isRedirecting, setIsRedirecting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
+  const router = useRouter();
+  const { update } = useSession();
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -26,14 +30,24 @@ export default function LoginForm() {
     if (result?.error) {
       setErrorMessage('メールアドレスまたはパスワードが正しくありません。');
       setIsPending(false);
+    } else if (result?.ok) {
+      // 認証成功時はリダイレクト状態に変更（ローディング継続）
+      setIsRedirecting(true);
+      
+      // セッションを強制更新してからリダイレクト
+      await update();
+      router.push('/dashboard');
     } else {
-      window.location.href = '/dashboard';
+      // 予期しないレスポンス
+      setErrorMessage('ログイン処理中にエラーが発生しました。');
+      setIsPending(false);
     }
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6" role="form">
-      <div className="flex-1 rounded-xl bg-white px-10 pb-10 pt-12 border border-gray-200 shadow-lg">
+    <div className="relative">
+      <form onSubmit={handleSubmit} className="space-y-6" role="form">
+        <div className="flex-1 rounded-xl bg-white px-10 pb-10 pt-12 border border-gray-200 shadow-lg">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-gray-900">
             ログイン
@@ -110,8 +124,8 @@ export default function LoginForm() {
           </div>
         </div>
         <Button type="submit" className="mt-8 w-full py-4 text-base font-medium justify-center"
-                aria-disabled={isPending}>
-          {isPending ? (
+                aria-disabled={isPending || isRedirecting}>
+          {isPending || isRedirecting ? (
             <div className="flex items-center justify-center">
               <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none"
                    viewBox="0 0 24 24">
@@ -119,7 +133,7 @@ export default function LoginForm() {
                 <path className="opacity-75" fill="currentColor"
                       d="m4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
               </svg>
-              ログイン中...
+              {isRedirecting ? 'ダッシュボードに移動中...' : 'ログイン中...'}
             </div>
           ) : (
             "ログイン"
@@ -127,5 +141,21 @@ export default function LoginForm() {
         </Button>
       </div>
     </form>
+    
+    {/* ログイン成功後のリダイレクト中はオーバーレイを表示 */}
+    {isRedirecting && (
+      <div className="absolute inset-0 bg-white bg-opacity-90 flex items-center justify-center rounded-xl z-10">
+        <div className="flex items-center justify-center flex-col">
+          <svg className="animate-spin h-8 w-8 text-blue-600 mb-2" xmlns="http://www.w3.org/2000/svg" fill="none"
+               viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+            <path className="opacity-75" fill="currentColor"
+                  d="m4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+          <p className="text-blue-600 font-medium">ダッシュボードに移動中...</p>
+        </div>
+      </div>
+    )}
+  </div>
   );
 }

--- a/src/components/SessionProvider.tsx
+++ b/src/components/SessionProvider.tsx
@@ -10,5 +10,13 @@ interface Props {
 }
 
 export default function NextAuthSessionProvider({ children, session }: Props) {
-  return <SessionProvider session={session}>{children}</SessionProvider>;
+  return (
+    <SessionProvider 
+      session={session}
+      refetchInterval={0} // 自動更新を無効化（手動更新を使用）
+      refetchOnWindowFocus={true} // ウィンドウフォーカス時にセッション更新
+    >
+      {children}
+    </SessionProvider>
+  );
 }


### PR DESCRIPTION
## 関連Issue

Closes #55

## 概要

ログインボタン押下後に一瞬ログインフォームが表示される問題を修正しました。UXフォーカスのアプローチでビジュアルオーバーレイを使用してフリッカーを解決しています。

## 変更内容

- [x] LoginForm.tsx：リダイレクトオーバーレイの追加とisRedirectingステート管理
- [x] ClientLayout.tsx：パス遷移検知とisTransitioning状態管理の実装
- [x] SessionProvider.tsx：手動セッション制御のためrefetchInterval無効化
- [x] テストファイル：新機能に対応したテスト更新とモック改善

## 変更理由

ユーザーからのフィードバック「やっぱり一瞬ログインフォームのこるね」「修正難しそう」を受け、NextAuth v5のセッションタイミング根本修正ではなく、UX重視でビジュアル面からの解決を採用しました。

## 動作確認

- [x] ログイン成功時のスムーズな遷移（フリッカーなし）
- [x] ローディング状態の適切な表示
- [x] 全テスト通過（526テスト）
- [x] TypeScriptビルド成功

## スクリーンショット

### Before

ログインボタン押下後に一瞬ログインフォームが表示される

### After

リダイレクトオーバーレイとローディングスピナーでスムーズな遷移

## 補足事項

NextAuth v5のセッションタイミング問題の根本解決ではなく、ユーザー体験を重視したビジュアル解決アプローチです。全テスト通過しTypeScriptビルドも成功しています。